### PR TITLE
Add Implementation for AppCompat

### DIFF
--- a/uicomponent/build.gradle.kts
+++ b/uicomponent/build.gradle.kts
@@ -61,4 +61,5 @@ dependencies {
 
     // Coil Image Loader
     implementation("io.coil-kt:coil-compose:2.6.0")
+    implementation("androidx.appcompat:appcompat:1.3.1")
 }


### PR DESCRIPTION
Will throw the errror` AAPT: error: resource attr/colorControlNormal (aka com.android.swingmusic.uicomponent:attr/colorControlNormal) not found.` if it isnt implemented