### PR TITLE
Fix CI APK Signing Path

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -24,7 +24,7 @@ jobs:
           echo "${{ secrets.KEYSTORE_FILE }}" | base64 -d > release-key.keystore
           wget https://github.com/patrickfav/uber-apk-signer/releases/download/v1.3.0/uber-apk-signer-1.3.0.jar
           java -jar uber-apk-signer-1.3.0.jar \
-            --apks ./app/build/outputs/apk/release/app-release-unsigned.apk \
+            --apks ./app/build/outputs/apk/release/app-release.apk \
             --ks release-key.keystore \
             --ksAlias ${{ secrets.KEYSTORE_ALIAS }} \
             --ksPass ${{ secrets.KEYSTORE_PASSWORD }} \


### PR DESCRIPTION
Use app-release.apk instead of app-release-unsigned.apk as the Gradle build outputs the former.