### PR TITLE
`player:` Add Player Animations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ local.properties
 *.keystore
 keystore-base64.txt
 /.kotlin/sessions
+/application.backup

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -17,7 +17,6 @@
         android:fullBackupContent="@xml/backup_rules"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
-        android:resizeableActivity="false"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.SwingMusic"
@@ -34,10 +33,8 @@
         </service>
 
         <activity
-            android:name=".presentation.activity.MainActivity"
+            android:name=".presentation.activity.MainActivityWithAnimatedPlayer"
             android:exported="true"
-            android:screenOrientation="portrait"
-            android:configChanges="orientation"
             android:theme="@style/Theme.SwingMusic">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -35,6 +35,7 @@
         <activity
             android:name=".presentation.activity.MainActivityWithAnimatedPlayer"
             android:exported="true"
+            android:screenOrientation="portrait"
             android:theme="@style/Theme.SwingMusic">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/app/src/main/java/com/android/swingmusic/presentation/activity/MainActivity.kt
+++ b/app/src/main/java/com/android/swingmusic/presentation/activity/MainActivity.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package com.android.swingmusic.presentation.activity
 
 import android.annotation.SuppressLint
@@ -87,6 +89,10 @@ import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 
+@Deprecated(
+    message = "Legacy MainActivity. Use MainActivityWithAnimatedPlayer instead.",
+    replaceWith = ReplaceWith("MainActivityWithAnimatedPlayer")
+)
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
     private val mediaControllerViewModel: MediaControllerViewModel by viewModels<MediaControllerViewModel>()

--- a/app/src/main/java/com/android/swingmusic/presentation/activity/MainActivityWithAnimatedPlayer.kt
+++ b/app/src/main/java/com/android/swingmusic/presentation/activity/MainActivityWithAnimatedPlayer.kt
@@ -283,22 +283,15 @@ class MainActivityWithAnimatedPlayer : ComponentActivity() {
                         }
 
                         isUserLoggedIn?.let { value ->
+                            val navigator = CoreNavigator(navController)
+
                             // Always use AnimatedPlayerSheet - it handles "no track" case internally
                             AnimatedPlayerSheet(
                                 paddingValues = paddingValues,
                                 mediaControllerViewModel = mediaControllerViewModel,
+                                navigator = navigator,
                                 onProgressChange = { progress ->
                                     sheetProgress = progress
-                                },
-                                onClickArtist = { artistHash ->
-                                    navController.navigate(
-                                        ArtistInfoScreenDestination(
-                                            artistHash = artistHash,
-                                            loadNewArtist = true
-                                        ).route
-                                    ) {
-                                        launchSingleTop = true
-                                    }
                                 }
                             ) {
                                 SwingMusicAppNavigationWithAnimatedPlayer(

--- a/app/src/main/java/com/android/swingmusic/presentation/activity/MainActivityWithAnimatedPlayer.kt
+++ b/app/src/main/java/com/android/swingmusic/presentation/activity/MainActivityWithAnimatedPlayer.kt
@@ -1,0 +1,410 @@
+package com.android.swingmusic.presentation.activity
+
+import android.annotation.SuppressLint
+import android.content.ComponentName
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.activity.viewModels
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.ExperimentalAnimationApi
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.offset
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.NavigationBar
+import androidx.compose.material3.NavigationBarItem
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.lifecycleScope
+import androidx.media3.session.MediaController
+import androidx.media3.session.SessionToken
+import androidx.navigation.NavHostController
+import androidx.navigation.compose.currentBackStackEntryAsState
+import androidx.navigation.compose.rememberNavController
+import com.android.swingmusic.album.presentation.screen.destinations.AlbumWithInfoScreenDestination
+import com.android.swingmusic.album.presentation.screen.destinations.AllAlbumScreenDestination
+import com.android.swingmusic.artist.presentation.screen.destinations.AllArtistsScreenDestination
+import com.android.swingmusic.artist.presentation.screen.destinations.ArtistInfoScreenDestination
+import com.android.swingmusic.artist.presentation.screen.destinations.ViewAllScreenOnArtistDestination
+import com.android.swingmusic.artist.presentation.viewmodel.ArtistInfoViewModel
+import com.android.swingmusic.auth.data.workmanager.scheduleTokenRefreshWork
+import com.android.swingmusic.auth.presentation.screen.destinations.LoginWithQrCodeDestination
+import com.android.swingmusic.auth.presentation.screen.destinations.LoginWithUsernameScreenDestination
+import com.android.swingmusic.auth.presentation.viewmodel.AuthViewModel
+import com.android.swingmusic.folder.presentation.event.FolderUiEvent
+import com.android.swingmusic.folder.presentation.screen.destinations.FoldersAndTracksScreenDestination
+import com.android.swingmusic.folder.presentation.viewmodel.FoldersViewModel
+import com.android.swingmusic.player.presentation.screen.AnimatedPlayerSheet
+import com.android.swingmusic.player.presentation.viewmodel.MediaControllerViewModel
+import com.android.swingmusic.presentation.navigator.BottomNavItem
+import com.android.swingmusic.presentation.navigator.CoreNavigator
+import com.android.swingmusic.presentation.navigator.NavGraphs
+import com.android.swingmusic.presentation.navigator.scaleInEnterTransition
+import com.android.swingmusic.presentation.navigator.scaleInPopEnterTransition
+import com.android.swingmusic.presentation.navigator.scaleOutExitTransition
+import com.android.swingmusic.presentation.navigator.scaleOutPopExitTransition
+import com.android.swingmusic.search.presentation.event.SearchUiEvent
+import com.android.swingmusic.search.presentation.screen.destinations.SearchScreenDestination
+import com.android.swingmusic.search.presentation.screen.destinations.ViewAllSearchResultsDestination
+import com.android.swingmusic.search.presentation.viewmodel.SearchViewModel
+import com.android.swingmusic.service.PlaybackService
+import com.android.swingmusic.service.SessionTokenManager
+import com.android.swingmusic.uicomponent.presentation.theme.SwingMusicTheme
+import com.google.accompanist.navigation.material.ExperimentalMaterialNavigationApi
+import com.google.common.util.concurrent.ListenableFuture
+import com.google.common.util.concurrent.MoreExecutors
+import com.ramcosta.composedestinations.DestinationsNavHost
+import com.ramcosta.composedestinations.animations.defaults.NestedNavGraphDefaultAnimations
+import com.ramcosta.composedestinations.animations.defaults.RootNavGraphDefaultAnimations
+import com.ramcosta.composedestinations.animations.rememberAnimatedNavHostEngine
+import com.ramcosta.composedestinations.navigation.dependency
+import android.Manifest
+import android.os.Build
+import androidx.activity.enableEdgeToEdge
+import com.android.swingmusic.BuildConfig
+import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.launch
+import kotlin.math.roundToInt
+
+/**
+ * MainActivityWithAnimatedPlayer - Alternative MainActivity with animated bottom sheet player.
+ *
+ * This activity replaces the traditional MiniPlayer + navigation-based NowPlaying approach
+ * with a continuous drag-animated bottom sheet that transforms from mini player to full player.
+ *
+ * Key differences from MainActivity:
+ * - Uses AnimatedPlayerSheet instead of MiniPlayer
+ * - Navigation bar animates based on sheet expansion progress
+ * - No navigation to NowPlayingScreen - player is always a sheet overlay
+ *
+ * To use this activity:
+ * 1. Update AndroidManifest.xml to set this as the launcher activity
+ * 2. Or change the activity reference in your launch intent
+ */
+@AndroidEntryPoint
+class MainActivityWithAnimatedPlayer : ComponentActivity() {
+    private val mediaControllerViewModel: MediaControllerViewModel by viewModels<MediaControllerViewModel>()
+    private val authViewModel: AuthViewModel by viewModels<AuthViewModel>()
+    private val foldersViewModel: FoldersViewModel by viewModels<FoldersViewModel>()
+    private val artistInfoViewModel: ArtistInfoViewModel by viewModels<ArtistInfoViewModel>()
+    private val searchViewModel: SearchViewModel by viewModels<SearchViewModel>()
+
+    private lateinit var controllerFuture: ListenableFuture<MediaController>
+
+    override fun onStart() {
+        super.onStart()
+
+        lifecycleScope.launch {
+            authViewModel.isUserLoggedIn.collectLatest {
+                if (it == true) {
+                    initializeMediaController()
+                }
+            }
+        }
+    }
+
+    @SuppressLint("UnusedMaterial3ScaffoldPaddingParameter")
+    @OptIn(ExperimentalAnimationApi::class)
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        if (BuildConfig.DEBUG && Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            requestPermissions(arrayOf(Manifest.permission.POST_NOTIFICATIONS), 0)
+        }
+
+        scheduleTokenRefreshWork(applicationContext)
+
+        // enableEdgeToEdge()
+
+        setContent {
+            val isUserLoggedIn by authViewModel.isUserLoggedIn.collectAsState()
+
+            val playerState = mediaControllerViewModel.playerUiState.collectAsState()
+
+            val navController = rememberNavController()
+            val newBackStackEntry by navController.currentBackStackEntryAsState()
+            val route = newBackStackEntry?.destination?.route
+
+            // Destinations where bottom nav should be hidden (check by route string)
+            val hideForRoutes = listOf(
+                LoginWithUsernameScreenDestination.route,
+                LoginWithQrCodeDestination.route
+            )
+
+            val showBottomNav = route != null && hideForRoutes.none { route.startsWith(it) }
+
+            val bottomNavItems: List<BottomNavItem> = listOf(
+                // BottomNavItem.Home,
+                BottomNavItem.Folder,
+                BottomNavItem.Album,
+                // BottomNavItem.Playlist,
+                BottomNavItem.Artist,
+                BottomNavItem.Search,
+            )
+
+            // Map of BottomNavItem to their route prefixes
+            val bottomNavRoutePrefixes = mapOf(
+                // BottomNavItem.Home to listOf(HomeDestination.route),
+                BottomNavItem.Folder to listOf(FoldersAndTracksScreenDestination.route),
+                BottomNavItem.Album to listOf(
+                    AllAlbumScreenDestination.route,
+                    AlbumWithInfoScreenDestination.route
+                ),
+                BottomNavItem.Artist to listOf(
+                    AllArtistsScreenDestination.route,
+                    ArtistInfoScreenDestination.route,
+                    ViewAllScreenOnArtistDestination.route
+                ),
+                BottomNavItem.Search to listOf(
+                    SearchScreenDestination.route,
+                    ViewAllSearchResultsDestination.route
+                )
+            )
+
+            // Track sheet progress for nav bar animation
+            var sheetProgress by remember { mutableFloatStateOf(0f) }
+
+            // Calculate nav bar animation values
+            val navBarSlideProgress = (sheetProgress / 0.2f).coerceIn(0f, 1f)
+            val navBarAlpha = 1f - navBarSlideProgress
+
+            SwingMusicTheme {
+                Scaffold(
+                    modifier = Modifier.fillMaxSize(),
+                    bottomBar = {
+                        // Only show navigation bar when logged in and not on auth screens
+                        if (showBottomNav) {
+                            val density = LocalDensity.current
+                            val navBarHeightPx = with(density) { 80.dp.toPx() }
+
+                            NavigationBar(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .offset {
+                                        IntOffset(
+                                            0,
+                                            (navBarHeightPx * navBarSlideProgress).roundToInt()
+                                        )
+                                    }
+                                    .alpha(navBarAlpha),
+                                containerColor = MaterialTheme.colorScheme.inverseOnSurface
+                            ) {
+                                Row(
+                                    modifier = Modifier.fillMaxWidth(),
+                                    horizontalArrangement = Arrangement.Center
+                                ) {
+                                    bottomNavItems.forEach { item ->
+                                        NavigationBarItem(
+                                            icon = {
+                                                Icon(
+                                                    painter = painterResource(id = item.icon),
+                                                    contentDescription = null
+                                                )
+                                            },
+                                            selected = navController.currentDestination?.route?.let { route ->
+                                                bottomNavRoutePrefixes[item]?.any { prefix ->
+                                                    route.startsWith(prefix)
+                                                } == true
+                                            } == true,
+                                            alwaysShowLabel = false,
+                                            label = { Text(text = item.title) },
+                                            onClick = {
+                                                // Whatever you do, DON'T TOUCH this
+                                                if (navController.currentDestination?.route != item.destination.route) {
+                                                    navController.navigate(item.destination.route) {
+                                                        launchSingleTop = true
+                                                        restoreState = false
+
+                                                        popUpTo(navController.graph.startDestinationId) {
+                                                            saveState = false
+                                                            inclusive = false
+                                                        }
+                                                    }
+                                                }
+
+                                                // refresh folders starting from $home
+                                                if (item.destination.route == FoldersAndTracksScreenDestination.route) {
+                                                    foldersViewModel.onFolderUiEvent(
+                                                        FolderUiEvent.OnClickNavPath(
+                                                            folder = foldersViewModel.homeDir
+                                                        )
+                                                    )
+                                                }
+
+                                                // refresh Search screen
+                                                if (item.destination.route == SearchScreenDestination.route) {
+                                                    searchViewModel.onSearchUiEvent(
+                                                        SearchUiEvent.OnClearSearchStates
+                                                    )
+                                                }
+                                            }
+                                        )
+                                    }
+                                }
+                            }
+                        }
+                    }
+                ) { paddingValues ->
+                    Surface(modifier = Modifier.fillMaxSize()) {
+                        AnimatedVisibility(
+                            visible = isUserLoggedIn == null,
+                            enter = fadeIn(animationSpec = tween(durationMillis = 100))
+                        ) {
+                            Box(
+                                modifier = Modifier.fillMaxSize(),
+                                contentAlignment = Alignment.Center
+                            ) {
+                                CircularProgressIndicator()
+                            }
+                        }
+
+                        isUserLoggedIn?.let { value ->
+                            // Always use AnimatedPlayerSheet - it handles "no track" case internally
+                            AnimatedPlayerSheet(
+                                paddingValues = paddingValues,
+                                mediaControllerViewModel = mediaControllerViewModel,
+                                onProgressChange = { progress ->
+                                    sheetProgress = progress
+                                },
+                                onClickArtist = { artistHash ->
+                                    navController.navigate(
+                                        ArtistInfoScreenDestination(
+                                            artistHash = artistHash,
+                                            loadNewArtist = true
+                                        ).route
+                                    ) {
+                                        launchSingleTop = true
+                                    }
+                                }
+                            ) {
+                                SwingMusicAppNavigationWithAnimatedPlayer(
+                                    isUserLoggedIn = value,
+                                    navController = navController,
+                                    authViewModel = authViewModel,
+                                    mediaControllerViewModel = mediaControllerViewModel,
+                                    foldersViewModel = foldersViewModel,
+                                    artistInfoViewModel = artistInfoViewModel,
+                                    searchViewModel = searchViewModel
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private fun initializeMediaController() {
+        if (
+            mediaControllerViewModel.getMediaController() == null ||
+            (this::controllerFuture.isInitialized).not()
+        ) {
+            val sessionToken = SessionTokenManager.sessionToken
+            if (sessionToken != null) {
+                // Use the existing session token to build the MediaController
+                controllerFuture = MediaController.Builder(this, sessionToken).buildAsync()
+                controllerFuture.addListener(
+                    {
+                        val mediaController = controllerFuture.get()
+                        mediaControllerViewModel.reconnectMediaController(mediaController)
+                    }, MoreExecutors.directExecutor()
+                )
+            } else {
+                // Create a new session token if no existing token is found
+                val newSessionToken =
+                    SessionToken(this, ComponentName(this, PlaybackService::class.java))
+
+                controllerFuture = MediaController.Builder(this, newSessionToken).buildAsync()
+                controllerFuture.addListener(
+                    {
+                        val mediaController = controllerFuture.get()
+                        mediaControllerViewModel.setMediaController(mediaController)
+                    }, MoreExecutors.directExecutor()
+                )
+            }
+        }
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        if (this::controllerFuture.isInitialized) {
+            mediaControllerViewModel.releaseMediaController(controllerFuture)
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterialNavigationApi::class)
+@ExperimentalAnimationApi
+@Composable
+internal fun SwingMusicAppNavigationWithAnimatedPlayer(
+    isUserLoggedIn: Boolean,
+    navController: NavHostController,
+    authViewModel: AuthViewModel,
+    mediaControllerViewModel: MediaControllerViewModel,
+    foldersViewModel: FoldersViewModel,
+    artistInfoViewModel: ArtistInfoViewModel,
+    searchViewModel: SearchViewModel
+) {
+    val navGraph = remember(isUserLoggedIn) { NavGraphs.root(isUserLoggedIn) }
+
+    val animatedNavHostEngine = rememberAnimatedNavHostEngine(
+        navHostContentAlignment = Alignment.TopCenter,
+        rootDefaultAnimations = RootNavGraphDefaultAnimations.ACCOMPANIST_FADING,
+        defaultAnimationsForNestedNavGraph = mapOf(
+            NavGraphs.root(isUserLoggedIn) to NestedNavGraphDefaultAnimations(
+                enterTransition = {
+                    scaleInEnterTransition()
+                },
+                exitTransition = {
+                    scaleOutExitTransition()
+                },
+                popEnterTransition = {
+                    scaleInPopEnterTransition()
+                },
+                popExitTransition = {
+                    scaleOutPopExitTransition()
+                }
+            )
+        )
+    )
+
+    DestinationsNavHost(
+        engine = animatedNavHostEngine,
+        navController = navController,
+        navGraph = navGraph,
+        dependenciesContainerBuilder = {
+            dependency(
+                CoreNavigator(navController = navController)
+            )
+            dependency(authViewModel)
+            dependency(foldersViewModel)
+            dependency(mediaControllerViewModel)
+            dependency(artistInfoViewModel)
+            dependency(searchViewModel)
+        }
+    )
+}

--- a/app/src/main/java/com/android/swingmusic/presentation/navigator/BottomNavItem.kt
+++ b/app/src/main/java/com/android/swingmusic/presentation/navigator/BottomNavItem.kt
@@ -11,29 +11,34 @@ import com.android.swingmusic.uicomponent.R as UiComponent
 sealed class BottomNavItem(
     var title: String,
     @param:DrawableRes var icon: Int,
+    @param:DrawableRes var animatedIcon: Int,
     var destination: DestinationSpec<*>
 ) {
     data object Folder : BottomNavItem(
         title = "Folders",
         icon = UiComponent.drawable.folder_filled,
+        animatedIcon = UiComponent.drawable.avd_folder,
         destination = FoldersAndTracksScreenDestination
     )
 
     data object Album : BottomNavItem(
         title = "Albums",
         icon = UiComponent.drawable.ic_album,
+        animatedIcon = UiComponent.drawable.avd_album,
         destination = AllAlbumScreenDestination
     )
 
     data object Artist : BottomNavItem(
         title = "Artists",
         icon = UiComponent.drawable.ic_artist,
+        animatedIcon = UiComponent.drawable.avd_artist,
         destination = AllArtistsScreenDestination
     )
 
     data object Search : BottomNavItem(
         title = "Search",
         icon = UiComponent.drawable.ic_search,
+        animatedIcon = UiComponent.drawable.avd_search,
         destination = SearchScreenDestination
     )
 }

--- a/auth/build.gradle.kts
+++ b/auth/build.gradle.kts
@@ -18,7 +18,7 @@ android {
 
     buildTypes {
         release {
-            isMinifyEnabled = true
+            isMinifyEnabled = false
         }
     }
     compileOptions {

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -15,7 +15,7 @@ android {
 
     buildTypes {
         release {
-            isMinifyEnabled = true
+            isMinifyEnabled = false
         }
     }
     compileOptions {

--- a/database/build.gradle.kts
+++ b/database/build.gradle.kts
@@ -16,7 +16,9 @@ android {
 
     buildTypes {
         release {
-            isMinifyEnabled = true
+            // Disabled: Hilt annotation processing in app module needs to see DAO classes
+            // App module's R8 will still minify this code in the final APK
+            isMinifyEnabled = false
         }
     }
     compileOptions {

--- a/feature/album/build.gradle.kts
+++ b/feature/album/build.gradle.kts
@@ -18,7 +18,7 @@ android {
 
     buildTypes {
         release {
-            isMinifyEnabled = true
+            isMinifyEnabled = false
         }
     }
     compileOptions {

--- a/feature/artist/build.gradle.kts
+++ b/feature/artist/build.gradle.kts
@@ -18,7 +18,7 @@ android {
 
     buildTypes {
         release {
-            isMinifyEnabled = true
+            isMinifyEnabled = false
         }
     }
     compileOptions {

--- a/feature/artist/src/main/java/com/android/swingmusic/artist/presentation/screen/AllArtists.kt
+++ b/feature/artist/src/main/java/com/android/swingmusic/artist/presentation/screen/AllArtists.kt
@@ -103,7 +103,6 @@ private fun AllArtists(
 
     var isGridCountMenuExpanded by remember { mutableStateOf(false) }
 
-    // TODO: Add pinch to reduce Grid count... as seen in Google Photos
     Scaffold {
         Scaffold(
             modifier = Modifier.padding(it),

--- a/feature/folder/build.gradle.kts
+++ b/feature/folder/build.gradle.kts
@@ -18,7 +18,7 @@ android {
 
     buildTypes {
         release {
-            isMinifyEnabled = true
+            isMinifyEnabled = false
         }
     }
     compileOptions {

--- a/feature/folder/src/main/java/com/android/swingmusic/folder/presentation/screen/FoldersAndTracks.kt
+++ b/feature/folder/src/main/java/com/android/swingmusic/folder/presentation/screen/FoldersAndTracks.kt
@@ -444,6 +444,7 @@ private fun FoldersAndTracks(
 
                         if (pagingContent.itemCount == 0 &&
                             pagingContent.loadState.refresh !is LoadState.Loading &&
+                            pagingContent.loadState.refresh !is LoadState.Error &&
                             !isManualRefreshing
                         ) {
                             item {

--- a/feature/folder/src/main/java/com/android/swingmusic/folder/presentation/screen/FoldersAndTracks.kt
+++ b/feature/folder/src/main/java/com/android/swingmusic/folder/presentation/screen/FoldersAndTracks.kt
@@ -57,8 +57,8 @@ import com.android.swingmusic.core.domain.util.BottomSheetAction
 import com.android.swingmusic.core.domain.util.PlaybackState
 import com.android.swingmusic.core.domain.util.QueueSource
 import com.android.swingmusic.folder.presentation.event.FolderUiEvent
-import com.android.swingmusic.folder.presentation.state.FoldersContentPagingState
 import com.android.swingmusic.folder.presentation.model.FolderContentItem
+import com.android.swingmusic.folder.presentation.state.FoldersContentPagingState
 import com.android.swingmusic.folder.presentation.viewmodel.FoldersViewModel
 import com.android.swingmusic.player.presentation.event.QueueEvent
 import com.android.swingmusic.player.presentation.viewmodel.MediaControllerViewModel
@@ -67,6 +67,7 @@ import com.android.swingmusic.uicomponent.presentation.component.CustomTrackBott
 import com.android.swingmusic.uicomponent.presentation.component.FolderItem
 import com.android.swingmusic.uicomponent.presentation.component.PathIndicatorItem
 import com.android.swingmusic.uicomponent.presentation.component.TrackItem
+import com.android.swingmusic.uicomponent.presentation.theme.SwingMusicTheme
 import com.ramcosta.composedestinations.annotation.Destination
 import java.util.Locale
 
@@ -97,7 +98,7 @@ private fun FoldersAndTracks(
     var clickedTrack: Track? by remember { mutableStateOf(null) }
 
     val pagingContent = foldersContentPagingState.pagingContent.collectAsLazyPagingItems()
-    
+
     // Track state updates and reset manual refreshing
     LaunchedEffect(pagingContent.loadState, pagingContent.itemCount) {
         // Reset manual refreshing when content loads successfully
@@ -109,14 +110,17 @@ private fun FoldersAndTracks(
                         onManualRefreshingChange(false)
                     }
                 }
+
                 is LoadState.Error -> {
                     // Error occurred, stop refreshing
                     onManualRefreshingChange(false)
                 }
-                else -> { /* Keep refreshing */ }
+
+                else -> { /* Keep refreshing */
+                }
             }
         }
-        
+
         // Reset bottom sheet if content is refreshed
         if (pagingContent.loadState.refresh is LoadState.NotLoading) {
             if (clickedTrack != null) {
@@ -288,7 +292,7 @@ private fun FoldersAndTracks(
                                 key = { index -> index }
                             ) { index ->
                                 val contentItem = pagingContent[index] ?: return@items
-                                
+
                                 when (contentItem) {
                                     is FolderContentItem.FolderItem -> {
                                         FolderItem(
@@ -299,6 +303,7 @@ private fun FoldersAndTracks(
                                             onClickMoreVert = {}
                                         )
                                     }
+
                                     is FolderContentItem.TrackItem -> {
                                         val track = contentItem.track
                                         TrackItem(
@@ -310,8 +315,8 @@ private fun FoldersAndTracks(
                                             onClickTrackItem = {
                                                 // Get all tracks for queue creation
                                                 val allTracks = (0 until pagingContent.itemCount)
-                                                    .mapNotNull { i -> 
-                                                        (pagingContent[i] as? FolderContentItem.TrackItem)?.track 
+                                                    .mapNotNull { i ->
+                                                        (pagingContent[i] as? FolderContentItem.TrackItem)?.track
                                                     }
                                                 val trackIndex = allTracks.indexOf(track)
                                                 onClickTrackItem(trackIndex, allTracks)
@@ -324,7 +329,7 @@ private fun FoldersAndTracks(
                                     }
                                 }
                             }
-                            
+
                             // Add bottom spacing
                             item {
                                 Spacer(modifier = Modifier.height(200.dp))
@@ -344,6 +349,7 @@ private fun FoldersAndTracks(
                                     }
                                 }
                             }
+
                             is LoadState.Error -> {
                                 item {
                                     Box(
@@ -354,7 +360,8 @@ private fun FoldersAndTracks(
                                     ) {
                                         Column(horizontalAlignment = Alignment.CenterHorizontally) {
                                             Text(
-                                                text = appendState.error.message ?: "Error loading more content",
+                                                text = appendState.error.message
+                                                    ?: "Error loading more content",
                                                 textAlign = TextAlign.Center,
                                                 style = MaterialTheme.typography.bodyMedium
                                             )
@@ -366,6 +373,7 @@ private fun FoldersAndTracks(
                                     }
                                 }
                             }
+
                             else -> {}
                         }
 
@@ -384,6 +392,7 @@ private fun FoldersAndTracks(
                                     }
                                 }
                             }
+
                             is LoadState.Error -> {
                                 if (isManualRefreshing) {
                                     onManualRefreshingChange(false)
@@ -423,11 +432,13 @@ private fun FoldersAndTracks(
                                     }
                                 }
                             }
+
                             is LoadState.NotLoading -> {
                                 if (isManualRefreshing) {
                                     onManualRefreshingChange(false)
                                 }
                             }
+
                             else -> {}
                         }
 
@@ -492,10 +503,10 @@ fun FoldersAndTracksScreen(
 
     val playerUiState by mediaControllerViewModel.playerUiState.collectAsState()
     val baseUrl by mediaControllerViewModel.baseUrl.collectAsState()
-    
+
     val currentTrackHash = playerUiState.nowPlayingTrack?.trackHash ?: ""
     val playbackState = playerUiState.playbackState
-    
+
     var isManualRefreshing by remember { mutableStateOf(false) }
     var routeByGotoFolder by remember { mutableStateOf(false) }
     var hasInitializedWithBaseUrl by remember { mutableStateOf(false) }
@@ -504,17 +515,17 @@ fun FoldersAndTracksScreen(
     LaunchedEffect(Unit) {
         mediaControllerViewModel.refreshBaseUrl()
     }
-    
+
     LaunchedEffect(baseUrl) {
         if (baseUrl != null && !hasInitializedWithBaseUrl) {
             // Trigger root directories fetch now that base URL is available
             foldersViewModel.fetchRootDirectoriesWhenReady()
-            
+
             // Only reload content if we're at home directory AND not in a "go to folder" scenario
             if (currentFolder.path == "\$home" && gotoFolderName == null && gotoFolderPath == null) {
                 foldersViewModel.onFolderUiEvent(FolderUiEvent.OnClickFolder(currentFolder))
             }
-            
+
             hasInitializedWithBaseUrl = true
         }
     }
@@ -553,94 +564,96 @@ fun FoldersAndTracksScreen(
         }
     }
 
-    FoldersAndTracks(
-        currentFolder = currentFolder,
-        homeDir = homeDir,
-        foldersContentPagingState = foldersViewModel.foldersContentPaging.value,
-        currentTrackHash = currentTrackHash,
-        playbackState = playbackState,
-        navPaths = navPaths,
-        onClickNavPath = { folder ->
-            routeByGotoFolder = false
-            foldersViewModel.onFolderUiEvent(FolderUiEvent.OnClickNavPath(folder))
-        },
-        onRetry = { event ->
-            foldersViewModel.onFolderUiEvent(event)
-        },
-        onPullToRefresh = { event ->
-            isManualRefreshing = true
-            foldersViewModel.onFolderUiEvent(event)
-        },
-        isManualRefreshing = isManualRefreshing,
-        onManualRefreshingChange = { isRefreshing ->
-            isManualRefreshing = isRefreshing
-        },
-        onClickFolder = { folder ->
-            routeByGotoFolder = false
-            foldersViewModel.onFolderUiEvent(FolderUiEvent.OnClickFolder(folder))
-        },
-        onClickTrackItem = { index, queue ->
-            mediaControllerViewModel.onQueueEvent(
-                QueueEvent.RecreateQueue(
-                    source = QueueSource.FOLDER(
-                        path = currentFolder.path,
-                        name = currentFolder.name
-                    ),
-                    queue = queue,
-                    clickedTrackIndex = index
-                    // Remove isPartialQueue - let ViewModel decide
-                )
-            )
-        },
-        onToggleTrackFavorite = { trackHash, isFavorite ->
-            foldersViewModel.onFolderUiEvent(
-                FolderUiEvent.ToggleTrackFavorite(
-                    trackHash,
-                    isFavorite
-                )
-            )
-        },
-        onGetSheetAction = { track, sheetAction ->
-            when (sheetAction) {
-                is BottomSheetAction.GotoAlbum -> {
-                    albumWithInfoViewModel.onAlbumWithInfoUiEvent(
-                        AlbumWithInfoUiEvent.OnLoadAlbumWithInfo(
-                            track.albumHash
-                        )
+    SwingMusicTheme {
+        FoldersAndTracks(
+            currentFolder = currentFolder,
+            homeDir = homeDir,
+            foldersContentPagingState = foldersViewModel.foldersContentPaging.value,
+            currentTrackHash = currentTrackHash,
+            playbackState = playbackState,
+            navPaths = navPaths,
+            onClickNavPath = { folder ->
+                routeByGotoFolder = false
+                foldersViewModel.onFolderUiEvent(FolderUiEvent.OnClickNavPath(folder))
+            },
+            onRetry = { event ->
+                foldersViewModel.onFolderUiEvent(event)
+            },
+            onPullToRefresh = { event ->
+                isManualRefreshing = true
+                foldersViewModel.onFolderUiEvent(event)
+            },
+            isManualRefreshing = isManualRefreshing,
+            onManualRefreshingChange = { isRefreshing ->
+                isManualRefreshing = isRefreshing
+            },
+            onClickFolder = { folder ->
+                routeByGotoFolder = false
+                foldersViewModel.onFolderUiEvent(FolderUiEvent.OnClickFolder(folder))
+            },
+            onClickTrackItem = { index, queue ->
+                mediaControllerViewModel.onQueueEvent(
+                    QueueEvent.RecreateQueue(
+                        source = QueueSource.FOLDER(
+                            path = currentFolder.path,
+                            name = currentFolder.name
+                        ),
+                        queue = queue,
+                        clickedTrackIndex = index
+                        // Remove isPartialQueue - let ViewModel decide
                     )
-                    navigator.gotoAlbumWithInfo(track.albumHash)
-                }
-
-                is BottomSheetAction.AddToQueue -> {
-                    mediaControllerViewModel.onQueueEvent(
-                        QueueEvent.AddToQueue(
-                            track = track,
-                            source = QueueSource.FOLDER(
-                                path = currentFolder.path,
-                                name = currentFolder.name
+                )
+            },
+            onToggleTrackFavorite = { trackHash, isFavorite ->
+                foldersViewModel.onFolderUiEvent(
+                    FolderUiEvent.ToggleTrackFavorite(
+                        trackHash,
+                        isFavorite
+                    )
+                )
+            },
+            onGetSheetAction = { track, sheetAction ->
+                when (sheetAction) {
+                    is BottomSheetAction.GotoAlbum -> {
+                        albumWithInfoViewModel.onAlbumWithInfoUiEvent(
+                            AlbumWithInfoUiEvent.OnLoadAlbumWithInfo(
+                                track.albumHash
                             )
                         )
-                    )
-                }
+                        navigator.gotoAlbumWithInfo(track.albumHash)
+                    }
 
-                is BottomSheetAction.PlayNext -> {
-                    mediaControllerViewModel.onQueueEvent(
-                        QueueEvent.PlayNext(
-                            track = track,
-                            source = QueueSource.FOLDER(
-                                path = currentFolder.path,
-                                name = currentFolder.name
+                    is BottomSheetAction.AddToQueue -> {
+                        mediaControllerViewModel.onQueueEvent(
+                            QueueEvent.AddToQueue(
+                                track = track,
+                                source = QueueSource.FOLDER(
+                                    path = currentFolder.path,
+                                    name = currentFolder.name
+                                )
                             )
                         )
-                    )
-                }
+                    }
 
-                else -> {}
-            }
-        },
-        onGotoArtist = { hash ->
-            navigator.gotoArtistInfo(hash)
-        },
-        baseUrl = baseUrl ?: ""
-    )
+                    is BottomSheetAction.PlayNext -> {
+                        mediaControllerViewModel.onQueueEvent(
+                            QueueEvent.PlayNext(
+                                track = track,
+                                source = QueueSource.FOLDER(
+                                    path = currentFolder.path,
+                                    name = currentFolder.name
+                                )
+                            )
+                        )
+                    }
+
+                    else -> {}
+                }
+            },
+            onGotoArtist = { hash ->
+                navigator.gotoArtistInfo(hash)
+            },
+            baseUrl = baseUrl ?: ""
+        )
+    }
 }

--- a/feature/folder/src/main/java/com/android/swingmusic/folder/presentation/screen/FoldersAndTracks.kt
+++ b/feature/folder/src/main/java/com/android/swingmusic/folder/presentation/screen/FoldersAndTracks.kt
@@ -548,7 +548,7 @@ fun FoldersAndTracksScreen(
         foldersViewModel.onFolderUiEvent(FolderUiEvent.OnBackNav(currentFolder))
     }
 
-    LaunchedEffect(key1 = Unit) {
+    LaunchedEffect(gotoFolderName, gotoFolderPath) {
         if (gotoFolderName != null && gotoFolderPath != null) {
             routeByGotoFolder = true
             foldersViewModel.resetNavPathsForGotoFolder(gotoFolderPath)

--- a/feature/home/build.gradle.kts
+++ b/feature/home/build.gradle.kts
@@ -17,7 +17,7 @@ android {
 
     buildTypes {
         release {
-            isMinifyEnabled = true
+            isMinifyEnabled = false
         }
     }
     compileOptions {

--- a/feature/player/build.gradle.kts
+++ b/feature/player/build.gradle.kts
@@ -18,7 +18,7 @@ android {
 
     buildTypes {
         release {
-            isMinifyEnabled = true
+            isMinifyEnabled = false
         }
     }
     compileOptions {

--- a/feature/player/src/main/java/com/android/swingmusic/player/presentation/screen/AnimatedPlayerSheet.kt
+++ b/feature/player/src/main/java/com/android/swingmusic/player/presentation/screen/AnimatedPlayerSheet.kt
@@ -87,6 +87,10 @@ import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalWindowInfo
+import androidx.compose.animation.graphics.ExperimentalAnimationGraphicsApi
+import androidx.compose.animation.graphics.res.animatedVectorResource
+import androidx.compose.animation.graphics.res.rememberAnimatedVectorPainter
+import androidx.compose.animation.graphics.vector.AnimatedImageVector
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
@@ -338,6 +342,7 @@ fun AnimatedPlayerSheet(
     }
 }
 
+@OptIn(ExperimentalAnimationGraphicsApi::class)
 @Composable
 private fun AnimatedSheetContent(
     track: Track,
@@ -698,10 +703,11 @@ private fun AnimatedSheetContent(
                                     strokeCap = StrokeCap.Round
                                 )
                             }
+                            val animatedPlayPause = AnimatedImageVector.animatedVectorResource(R.drawable.avd_play_pause)
                             Icon(
-                                painter = painterResource(
-                                    id = if (playbackState == PlaybackState.PLAYING)
-                                        R.drawable.pause_icon else R.drawable.play_arrow
+                                painter = rememberAnimatedVectorPainter(
+                                    animatedImageVector = animatedPlayPause,
+                                    atEnd = playbackState == PlaybackState.PLAYING
                                 ),
                                 contentDescription = "Play/Pause"
                             )
@@ -876,6 +882,10 @@ private fun AnimatedSheetContent(
                             Spacer(modifier = Modifier.height(24.dp))
 
                             // Playback controls
+                            // Animation toggle states for prev/next
+                            var prevAnimAtEnd by remember { mutableStateOf(false) }
+                            var nextAnimAtEnd by remember { mutableStateOf(false) }
+
                             Row(
                                 modifier = Modifier
                                     .fillMaxWidth()
@@ -883,16 +893,23 @@ private fun AnimatedSheetContent(
                                 verticalAlignment = Alignment.CenterVertically,
                                 horizontalArrangement = Arrangement.SpaceEvenly
                             ) {
+                                val animatedPrev = AnimatedImageVector.animatedVectorResource(R.drawable.avd_prev)
                                 IconButton(
                                     modifier = Modifier
                                         .clip(CircleShape)
                                         .background(
                                             MaterialTheme.colorScheme.secondaryContainer.copy(alpha = .5f)
                                         ),
-                                    onClick = { onClickPrev() }
+                                    onClick = {
+                                        prevAnimAtEnd = !prevAnimAtEnd
+                                        onClickPrev()
+                                    }
                                 ) {
                                     Icon(
-                                        painter = painterResource(id = R.drawable.prev),
+                                        painter = rememberAnimatedVectorPainter(
+                                            animatedImageVector = animatedPrev,
+                                            atEnd = prevAnimAtEnd
+                                        ),
                                         contentDescription = "Previous"
                                     )
                                 }
@@ -939,10 +956,14 @@ private fun AnimatedSheetContent(
                                                     .background(MaterialTheme.colorScheme.secondaryContainer),
                                                 contentAlignment = Alignment.Center
                                             ) {
+                                                val animatedPlayPauseLarge = AnimatedImageVector.animatedVectorResource(R.drawable.avd_play_pause)
                                                 Icon(
                                                     modifier = Modifier.size(44.dp),
                                                     tint = MaterialTheme.colorScheme.onSecondaryContainer,
-                                                    painter = painterResource(id = playbackStateIcon),
+                                                    painter = rememberAnimatedVectorPainter(
+                                                        animatedImageVector = animatedPlayPauseLarge,
+                                                        atEnd = playbackState == PlaybackState.PLAYING
+                                                    ),
                                                     contentDescription = "Play/Pause"
                                                 )
                                             }
@@ -959,16 +980,23 @@ private fun AnimatedSheetContent(
                                     }
                                 }
 
+                                val animatedNext = AnimatedImageVector.animatedVectorResource(R.drawable.avd_next)
                                 IconButton(
                                     modifier = Modifier
                                         .clip(CircleShape)
                                         .background(
                                             MaterialTheme.colorScheme.secondaryContainer.copy(alpha = .5f)
                                         ),
-                                    onClick = { onClickNext() }
+                                    onClick = {
+                                        nextAnimAtEnd = !nextAnimAtEnd
+                                        onClickNext()
+                                    }
                                 ) {
                                     Icon(
-                                        painter = painterResource(id = R.drawable.next),
+                                        painter = rememberAnimatedVectorPainter(
+                                            animatedImageVector = animatedNext,
+                                            atEnd = nextAnimAtEnd
+                                        ),
                                         tint = MaterialTheme.colorScheme.onSecondaryContainer,
                                         contentDescription = "Next"
                                     )

--- a/feature/player/src/main/java/com/android/swingmusic/player/presentation/screen/AnimatedPlayerSheet.kt
+++ b/feature/player/src/main/java/com/android/swingmusic/player/presentation/screen/AnimatedPlayerSheet.kt
@@ -1,0 +1,1293 @@
+@file:OptIn(ExperimentalMaterial3Api::class)
+
+package com.android.swingmusic.player.presentation.screen
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.AnimationVector1D
+import androidx.compose.animation.core.EaseOutQuad
+import androidx.compose.animation.core.FastOutSlowInEasing
+import androidx.compose.animation.core.LinearOutSlowInEasing
+import androidx.compose.animation.core.VectorConverter
+import androidx.compose.animation.core.spring
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.gestures.detectDragGestures
+import androidx.compose.foundation.gestures.detectHorizontalDragGestures
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.wrapContentSize
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.pager.HorizontalPager
+import androidx.compose.foundation.pager.rememberPagerState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.BottomSheetScaffold
+import androidx.compose.material3.BottomSheetScaffoldState
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.SheetValue
+import androidx.compose.material3.Text
+import androidx.compose.material3.rememberBottomSheetScaffoldState
+import androidx.compose.material3.rememberStandardBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshotFlow
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.lerp
+import androidx.compose.ui.unit.sp
+import coil.compose.AsyncImage
+import coil.request.ImageRequest
+import com.android.swingmusic.core.domain.model.Track
+import com.android.swingmusic.core.domain.util.PlaybackState
+import com.android.swingmusic.core.domain.util.QueueSource
+import com.android.swingmusic.core.domain.util.RepeatMode
+import com.android.swingmusic.core.domain.util.ShuffleMode
+import com.android.swingmusic.player.presentation.event.PlayerUiEvent
+import com.android.swingmusic.player.presentation.event.QueueEvent
+import com.android.swingmusic.player.presentation.util.calculateCurrentOffsetForPage
+import com.android.swingmusic.player.presentation.viewmodel.MediaControllerViewModel
+import com.android.swingmusic.uicomponent.R
+import com.android.swingmusic.uicomponent.presentation.util.BlurTransformation
+import com.android.swingmusic.uicomponent.presentation.util.formatDuration
+import ir.mahozad.multiplatform.wavyslider.WaveAnimationSpecs
+import ir.mahozad.multiplatform.wavyslider.WaveDirection
+import ir.mahozad.multiplatform.wavyslider.material3.WavySlider
+import kotlinx.coroutines.launch
+import java.util.Locale
+import kotlin.math.pow
+import kotlin.math.roundToInt
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.ui.platform.LocalWindowInfo
+import com.android.swingmusic.uicomponent.presentation.component.SoundSignalBars
+import com.android.swingmusic.uicomponent.presentation.component.TrackItem
+
+// Constants for sheet sizing (matching SheetDemo)
+private val INITIAL_IMAGE_SIZE = 38.dp
+private val INITIAL_PADDING = 8.dp
+private val TOTAL_INITIAL_SIZE = INITIAL_IMAGE_SIZE + INITIAL_PADDING
+
+/**
+ * Animated Bottom Sheet Player that transforms from a mini player to full player.
+ *
+ * Animation Behavior:
+ * - Image transforms from 38dp square to full width based on expansion progress
+ * - Content fades in at 20% expansion with dynamic spacing and padding
+ * - Sheet corners transition from rounded to square during expansion
+ * - Navigation bar in parent should animate out based on onProgressChange callback
+ *
+ * Queue Sheet:
+ * - Appears when primary sheet is 95%+ expanded
+ * - Custom draggable implementation with spring animations
+ * - Reverse animation effect: queue expansion reverses primary sheet visuals
+ */
+@Composable
+fun AnimatedPlayerSheet(
+    paddingValues: PaddingValues,
+    mediaControllerViewModel: MediaControllerViewModel,
+    onProgressChange: (progress: Float) -> Unit = {},
+    onClickArtist: (artistHash: String) -> Unit = {},
+    content: @Composable (PaddingValues) -> Unit
+) {
+    val playerUiState by mediaControllerViewModel.playerUiState.collectAsState()
+    val baseUrl by mediaControllerViewModel.baseUrl.collectAsState()
+
+    val track = playerUiState.nowPlayingTrack
+
+    // If no track playing, just show content without the sheet
+    if (track == null) {
+        content(paddingValues)
+        return
+    }
+
+    // Dynamic sheet corner shape
+    var dynamicShape by remember {
+        mutableStateOf(
+            RoundedCornerShape(topStart = 12.dp, topEnd = 12.dp)
+        )
+    }
+
+    // Track primary sheet progress for queue sheet trigger
+    var primarySheetProgress by remember { mutableFloatStateOf(0f) }
+
+    // Queue sheet calculations
+    val configuration = LocalWindowInfo.current
+    val density = LocalDensity.current
+    val screenHeightPx = with(density) { configuration.containerSize.height.dp.toPx() }
+    val queueInitialOffset = screenHeightPx * 1f // push sheet off-screen
+
+    // Calculate expanded offset based on initial image size + padding + system bar
+    val systemBarHeight = paddingValues.calculateTopPadding()
+    val imageHeightWithPadding = INITIAL_IMAGE_SIZE + (INITIAL_PADDING * 2) + systemBarHeight
+    val queueExpandedOffset = with(density) { imageHeightWithPadding.toPx() }
+
+    val queueSheetOffset = remember { Animatable(queueInitialOffset, Float.VectorConverter) }
+
+    val coroutineScope = rememberCoroutineScope()
+
+    // Peek height: image size + paddings (sits on top of bottom nav)
+    val calculatedPeekHeight = TOTAL_INITIAL_SIZE + INITIAL_PADDING + (INITIAL_PADDING/2) + paddingValues.calculateBottomPadding()
+
+    val bottomSheetState = rememberBottomSheetScaffoldState(
+        bottomSheetState = rememberStandardBottomSheetState(
+            initialValue = SheetValue.PartiallyExpanded,
+            skipHiddenState = true,
+            confirmValueChange = { newValue ->
+                newValue != SheetValue.Hidden
+            }
+        )
+    )
+
+    // Check if queue sheet is open
+    val isQueueSheetOpen = queueSheetOffset.value < (screenHeightPx * 0.25f)
+
+    // Calculate queue progress for primary sheet visual effects
+    val queueProgress by remember {
+        derivedStateOf {
+            val progress =
+                (queueInitialOffset - queueSheetOffset.value) / (queueInitialOffset - queueExpandedOffset)
+            progress.coerceIn(0f, 1f)
+        }
+    }
+
+    BottomSheetScaffold(
+        scaffoldState = bottomSheetState,
+        sheetPeekHeight = calculatedPeekHeight,
+        sheetMaxWidth = Dp.Unspecified,
+        sheetDragHandle = {},
+        sheetShape = dynamicShape,
+        sheetContainerColor = MaterialTheme.colorScheme.inverseOnSurface,
+        sheetSwipeEnabled = !isQueueSheetOpen,
+        sheetContent = {
+            AnimatedSheetContent(
+                track = track,
+                queue = playerUiState.queue,
+                playingTrackIndex = playerUiState.playingTrackIndex,
+                seekPosition = playerUiState.seekPosition,
+                playbackDuration = playerUiState.playbackDuration,
+                trackDuration = playerUiState.trackDuration,
+                playbackState = playerUiState.playbackState,
+                isBuffering = playerUiState.isBuffering,
+                repeatMode = playerUiState.repeatMode,
+                shuffleMode = playerUiState.shuffleMode,
+                baseUrl = baseUrl ?: "",
+                bottomSheetState = bottomSheetState,
+                systemBarHeight = systemBarHeight,
+                onShapeChange = { shape -> dynamicShape = shape },
+                onProgressChange = { progress ->
+                    primarySheetProgress = progress
+                    onProgressChange(progress)
+                },
+                primarySheetProgress = primarySheetProgress,
+                queueSheetOffset = queueSheetOffset,
+                queueInitialOffset = queueInitialOffset,
+                queueExpandedOffset = queueExpandedOffset,
+                queueProgress = queueProgress,
+                onPageSelect = { page ->
+                    mediaControllerViewModel.onQueueEvent(QueueEvent.SeekToQueueItem(page))
+                },
+                onClickArtist = onClickArtist,
+                onToggleRepeatMode = {
+                    mediaControllerViewModel.onPlayerUiEvent(PlayerUiEvent.OnToggleRepeatMode)
+                },
+                onClickPrev = {
+                    mediaControllerViewModel.onPlayerUiEvent(PlayerUiEvent.OnPrev)
+                },
+                onTogglePlayerState = {
+                    mediaControllerViewModel.onPlayerUiEvent(PlayerUiEvent.OnTogglePlayerState)
+                },
+                onResumePlayBackFromError = {
+                    mediaControllerViewModel.onPlayerUiEvent(PlayerUiEvent.OnResumePlaybackFromError)
+                },
+                onClickNext = {
+                    mediaControllerViewModel.onPlayerUiEvent(PlayerUiEvent.OnNext)
+                },
+                onToggleShuffleMode = {
+                    mediaControllerViewModel.onPlayerUiEvent(
+                        PlayerUiEvent.OnToggleShuffleMode(toggleShuffle = true)
+                    )
+                },
+                onSeekPlayBack = { value ->
+                    mediaControllerViewModel.onPlayerUiEvent(PlayerUiEvent.OnSeekPlayBack(value))
+                },
+                onToggleFavorite = { isFavorite, trackHash ->
+                    mediaControllerViewModel.onPlayerUiEvent(
+                        PlayerUiEvent.OnToggleFavorite(isFavorite, trackHash)
+                    )
+                }
+            )
+        }
+    ) { innerPadding ->
+        content(innerPadding)
+    }
+
+    // Queue Sheet - appears when primary sheet is fully expanded
+    if (primarySheetProgress >= 0.95f) {
+        QueueSheetOverlay(
+            queue = playerUiState.queue,
+            source = playerUiState.source,
+            playingTrackIndex = playerUiState.playingTrackIndex,
+            playingTrack = track,
+            playbackState = playerUiState.playbackState,
+            baseUrl = baseUrl ?: "",
+            animatedOffset = queueSheetOffset,
+            initialOffset = queueInitialOffset,
+            expandedOffset = queueExpandedOffset,
+            onClickQueueItem = { index ->
+                mediaControllerViewModel.onQueueEvent(QueueEvent.SeekToQueueItem(index))
+            },
+            onTogglePlayerState = {
+                mediaControllerViewModel.onPlayerUiEvent(PlayerUiEvent.OnTogglePlayerState)
+            }
+        )
+    }
+}
+
+@Composable
+private fun AnimatedSheetContent(
+    track: Track,
+    queue: List<Track>,
+    playingTrackIndex: Int,
+    seekPosition: Float,
+    playbackDuration: String,
+    trackDuration: String,
+    playbackState: PlaybackState,
+    isBuffering: Boolean,
+    repeatMode: RepeatMode,
+    shuffleMode: ShuffleMode,
+    baseUrl: String,
+    bottomSheetState: BottomSheetScaffoldState,
+    systemBarHeight: Dp,
+    onShapeChange: (RoundedCornerShape) -> Unit,
+    onProgressChange: (Float) -> Unit,
+    primarySheetProgress: Float,
+    queueSheetOffset: Animatable<Float, AnimationVector1D>,
+    queueInitialOffset: Float,
+    queueExpandedOffset: Float,
+    queueProgress: Float,
+    onPageSelect: (Int) -> Unit,
+    onClickArtist: (String) -> Unit,
+    onToggleRepeatMode: () -> Unit,
+    onClickPrev: () -> Unit,
+    onTogglePlayerState: () -> Unit,
+    onResumePlayBackFromError: () -> Unit,
+    onClickNext: () -> Unit,
+    onToggleShuffleMode: () -> Unit,
+    onSeekPlayBack: (Float) -> Unit,
+    onToggleFavorite: (Boolean, String) -> Unit
+) {
+    val coroutineScope = rememberCoroutineScope()
+    val configuration = LocalConfiguration.current
+    val density = LocalDensity.current
+    val screenWidthDp = configuration.screenWidthDp.dp
+
+    // Horizontal swipe state for collapsed mode
+    var swipeDistance by remember { mutableFloatStateOf(0f) }
+
+    // Store initial offset when first available
+    val initialOffset = remember { mutableStateOf<Float?>(null) }
+
+    // Calculate progress using actual initial offset
+    val progress = remember {
+        derivedStateOf {
+            try {
+                val currentOffset = bottomSheetState.bottomSheetState.requireOffset()
+
+                if (initialOffset.value == null && currentOffset.isFinite() && currentOffset > 0f) {
+                    initialOffset.value = currentOffset
+                }
+
+                val collapsedOffset = initialOffset.value ?: currentOffset
+                val expandedOffset = 0f
+                val range = collapsedOffset - expandedOffset
+
+                // Avoid division by zero or NaN
+                if (range <= 0f || !range.isFinite()) {
+                    when (bottomSheetState.bottomSheetState.currentValue) {
+                        SheetValue.PartiallyExpanded -> 0f
+                        SheetValue.Expanded -> 1f
+                        SheetValue.Hidden -> 0f
+                    }
+                } else {
+                    val rawProgress = (collapsedOffset - currentOffset) / range
+                    rawProgress.coerceIn(0f, 1f)
+                }
+            } catch (e: Exception) {
+                when (bottomSheetState.bottomSheetState.currentValue) {
+                    SheetValue.PartiallyExpanded -> 0f
+                    SheetValue.Expanded -> 1f
+                    SheetValue.Hidden -> 0f
+                }
+            }
+        }
+    }
+
+    // Effective progress considers queue sheet position
+    // When queue is fully up, effective progress becomes 0 (image shrinks back)
+    val effectiveProgress = progress.value * (1f - queueProgress)
+
+    // Image size interpolation with easing curve
+    val fraction = effectiveProgress.pow(0.75f)
+    val imageSize = lerp(INITIAL_IMAGE_SIZE, screenWidthDp, fraction).coerceAtMost(screenWidthDp)
+
+    // Image corner radius
+    val imageCornerRadius = lerp(8.dp, 16.dp, effectiveProgress)
+
+    // Dynamic top padding to avoid status bar overlay
+    val imageTopPadding = lerp(0.dp, systemBarHeight, progress.value)
+
+    // Dynamic spacing between image and content
+    val imageContentSpacing = lerp(60.dp, 16.dp, progress.value)
+
+    // Dynamic sheet corner radius: 12dp at peek → 0dp at 50% progress
+    val sheetCornerRadius = lerp(12.dp, 0.dp, (progress.value / 0.5f).coerceIn(0f, 1f))
+
+    // Dynamic container padding
+    val containerPadding = lerp(INITIAL_PADDING, 24.dp, effectiveProgress)
+
+    // Content opacity: starts at 20%, full at 80%
+    val contentOpacity = ((effectiveProgress - 0.2f) / 0.6f).coerceIn(0f, 1f)
+
+    // Mini player elements opacity (inverse)
+    val miniPlayerOpacity = (1f - (progress.value / 0.3f)).coerceIn(0f, 1f)
+
+    // Update the sheet shape
+    LaunchedEffect(sheetCornerRadius) {
+        onShapeChange(RoundedCornerShape(topStart = sheetCornerRadius, topEnd = sheetCornerRadius))
+    }
+
+    // Notify progress changes
+    LaunchedEffect(progress.value) {
+        onProgressChange(progress.value)
+    }
+
+    // Track info for file type badge
+    val fileType by remember(track.filepath) {
+        derivedStateOf {
+            track.filepath.substringAfterLast(".").uppercase(Locale.ROOT)
+        }
+    }
+
+    val isDarkTheme = isSystemInDarkTheme()
+    val inverseOnSurface = MaterialTheme.colorScheme.inverseOnSurface
+    val onSurface = MaterialTheme.colorScheme.onSurface
+    val fileTypeBadgeColor = when (track.bitrate) {
+        in 321..1023 -> if (isDarkTheme) Color(0xFF172B2E) else Color(0xFFAEFAF4)
+        in 1024..Int.MAX_VALUE -> if (isDarkTheme) Color(0XFF443E30) else Color(0xFFFFFBCC)
+        else -> inverseOnSurface
+    }
+    val fileTypeTextColor = when (track.bitrate) {
+        in 321..1023 -> if (isDarkTheme) Color(0XFF33FFEE) else Color(0xFF172B2E)
+        in 1024..Int.MAX_VALUE -> if (isDarkTheme) Color(0XFFEFE143) else Color(0xFF221700)
+        else -> onSurface
+    }
+
+    val animateWave = playbackState == PlaybackState.PLAYING && !isBuffering
+    val repeatModeIcon = when (repeatMode) {
+        RepeatMode.REPEAT_ONE -> R.drawable.repeat_one
+        else -> R.drawable.repeat_all
+    }
+    val playbackStateIcon = when (playbackState) {
+        PlaybackState.PLAYING -> R.drawable.pause_icon
+        PlaybackState.PAUSED -> R.drawable.play_arrow
+        PlaybackState.ERROR -> R.drawable.error
+    }
+
+    // Pager state for expanded mode artwork swiping
+    val pagerState = rememberPagerState(
+        initialPage = playingTrackIndex,
+        pageCount = { if (queue.isEmpty()) 1 else queue.size }
+    )
+
+    var isInitialComposition by remember { mutableStateOf(true) }
+
+    LaunchedEffect(playingTrackIndex, pagerState) {
+        if (playingTrackIndex in queue.indices) {
+            if (playingTrackIndex != pagerState.currentPage) {
+                pagerState.animateScrollToPage(playingTrackIndex)
+            }
+        }
+
+        snapshotFlow { pagerState.currentPage }.collect { page ->
+            if (isInitialComposition) {
+                isInitialComposition = false
+            } else {
+                if (playingTrackIndex != page) {
+                    onPageSelect(page)
+                }
+            }
+        }
+    }
+
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .fillMaxHeight()
+    ) {
+        // Blurred background (only visible when expanded)
+        if (effectiveProgress > 0.1f) {
+            AsyncImage(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .alpha(effectiveProgress),
+                model = ImageRequest.Builder(LocalContext.current)
+                    .data("${baseUrl}img/thumbnail/${track.image}")
+                    .crossfade(true)
+                    .transformations(listOf(BlurTransformation(scale = 0.25f, radius = 25)))
+                    .build(),
+                contentDescription = null,
+                contentScale = ContentScale.Crop
+            )
+
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .alpha(effectiveProgress)
+                    .background(
+                        Brush.verticalGradient(
+                            colors = listOf(
+                                MaterialTheme.colorScheme.surface.copy(alpha = .75f),
+                                MaterialTheme.colorScheme.surface.copy(alpha = 1f),
+                                MaterialTheme.colorScheme.surface.copy(alpha = 1f)
+                            )
+                        )
+                    )
+            )
+        }
+
+        Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .fillMaxHeight()
+            .padding(containerPadding)
+    ) {
+        // Image container with transformation
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(top = imageTopPadding)
+                .then(
+                    // Horizontal swipe for prev/next in collapsed state
+                    if (progress.value < 0.3f) {
+                        Modifier.pointerInput(Unit) {
+                            detectHorizontalDragGestures(
+                                onDragEnd = {
+                                    if (swipeDistance > 50) {
+                                        onClickPrev()
+                                    } else if (swipeDistance < -50) {
+                                        onClickNext()
+                                    }
+                                    swipeDistance = 0f
+                                }
+                            ) { change, dragAmount ->
+                                change.consume()
+                                swipeDistance += dragAmount
+                            }
+                        }
+                    } else Modifier
+                )
+                .clickable(
+                    indication = null,
+                    interactionSource = remember { MutableInteractionSource() }
+                ) {
+                    if (progress.value < 0.5f && queueProgress < 0.1f) {
+                        coroutineScope.launch {
+                            bottomSheetState.bottomSheetState.expand()
+                        }
+                    }
+                }
+        ) {
+            // Mini player row (visible when collapsed)
+            if (progress.value < 0.5f) {
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .alpha(miniPlayerOpacity)
+                        .offset { IntOffset((swipeDistance / 3).roundToInt(), 0) },
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.SpaceBetween
+                ) {
+                    Row(
+                        modifier = Modifier.weight(1f),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        // Image placeholder for collapsed state (actual image below)
+                        Spacer(modifier = Modifier.width(imageSize + 8.dp))
+
+                        Text(
+                            text = track.title,
+                            maxLines = 1,
+                            style = MaterialTheme.typography.bodyMedium,
+                            fontWeight = FontWeight.SemiBold,
+                            overflow = TextOverflow.Ellipsis,
+                            color = if (swipeDistance.toInt() != 0)
+                                MaterialTheme.colorScheme.onSurface.copy(alpha = .25f)
+                            else
+                                MaterialTheme.colorScheme.onSurface.copy(alpha = .84f)
+                        )
+                    }
+
+                    // Play/Pause button (collapsed state)
+                    IconButton(
+                        modifier = Modifier.padding(end = 8.dp),
+                        onClick = {
+                            if (playbackState == PlaybackState.ERROR) {
+                                onResumePlayBackFromError()
+                            } else {
+                                onTogglePlayerState()
+                            }
+                        }
+                    ) {
+                        if (isBuffering) {
+                            CircularProgressIndicator(
+                                modifier = Modifier.size(24.dp),
+                                strokeWidth = 0.75.dp,
+                                strokeCap = StrokeCap.Round
+                            )
+                        }
+                        Icon(
+                            painter = painterResource(
+                                id = if (playbackState == PlaybackState.PLAYING)
+                                    R.drawable.pause_icon else R.drawable.play_arrow
+                            ),
+                            contentDescription = "Play/Pause"
+                        )
+                    }
+                }
+            }
+
+            // Animated image (transforms from 38dp to full width)
+            if (effectiveProgress > 0.3f) {
+                // Use HorizontalPager for expanded state
+                HorizontalPager(
+                    modifier = Modifier.fillMaxWidth(),
+                    state = pagerState,
+                    beyondViewportPageCount = 2,
+                    verticalAlignment = Alignment.CenterVertically
+                ) { page ->
+                    val imageData = if (page == playingTrackIndex) {
+                        "${baseUrl}img/thumbnail/${queue.getOrNull(playingTrackIndex)?.image ?: track.image}"
+                    } else {
+                        "${baseUrl}img/thumbnail/${queue.getOrNull(page)?.image ?: track.image}"
+                    }
+                    val pageOffset = pagerState.calculateCurrentOffsetForPage(page)
+
+                    Column(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalAlignment = Alignment.CenterHorizontally
+                    ) {
+                        AsyncImage(
+                            modifier = Modifier
+                                .width(imageSize)
+                                .heightIn(max = imageSize)
+                                .aspectRatio(1f)
+                                .clip(RoundedCornerShape(imageCornerRadius))
+                                .graphicsLayer {
+                                    val scale =
+                                        androidx.compose.ui.util.lerp(1f, 1.25f, pageOffset)
+                                    scaleX = scale
+                                    scaleY = scale
+                                    clip = true
+                                    shape = RoundedCornerShape(imageCornerRadius)
+                                },
+                            model = ImageRequest.Builder(LocalContext.current)
+                                .data(imageData)
+                                .crossfade(true)
+                                .build(),
+                            placeholder = painterResource(R.drawable.audio_fallback),
+                            fallback = painterResource(R.drawable.audio_fallback),
+                            error = painterResource(R.drawable.audio_fallback),
+                            contentDescription = "Track Image",
+                            contentScale = ContentScale.Crop
+                        )
+                    }
+                }
+            } else {
+                // Simple image for collapsed/transitioning state
+                AsyncImage(
+                    modifier = Modifier
+                        .width(imageSize)
+                        .heightIn(max = imageSize)
+                        .aspectRatio(1f)
+                        .clip(RoundedCornerShape(imageCornerRadius))
+                        .align(Alignment.CenterStart),
+                    model = ImageRequest.Builder(LocalContext.current)
+                        .data("${baseUrl}img/thumbnail/small/${track.image}")
+                        .crossfade(true)
+                        .build(),
+                    placeholder = painterResource(R.drawable.audio_fallback),
+                    fallback = painterResource(R.drawable.audio_fallback),
+                    error = painterResource(R.drawable.audio_fallback),
+                    contentDescription = "Track Image",
+                    contentScale = ContentScale.Crop
+                )
+            }
+        }
+
+        // Progress bar for collapsed state
+        if (progress.value < 0.3f) {
+            LinearProgressIndicator(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(1.dp)
+                    .alpha(miniPlayerOpacity),
+                gapSize = 0.dp,
+                drawStopIndicator = {},
+                progress = { seekPosition },
+                strokeCap = StrokeCap.Square
+            )
+        }
+
+        // Image and Content spacer
+        Spacer(modifier = Modifier.height(imageContentSpacing))
+
+        // Expanded content (fades in at 20% progress)
+        AnimatedVisibility(
+            visible = effectiveProgress > 0.2f,
+            enter = fadeIn(animationSpec = tween(200)),
+            exit = fadeOut(animationSpec = tween(200))
+        ) {
+            Box(modifier = Modifier.alpha(contentOpacity)) {
+                Column(
+                    modifier = Modifier.fillMaxSize(),
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    verticalArrangement = Arrangement.SpaceBetween
+                ) {
+                    Column(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalAlignment = Alignment.CenterHorizontally
+                    ) {
+                        // Track title and artist
+                        Row(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(horizontal = 24.dp),
+                            horizontalArrangement = Arrangement.SpaceBetween,
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            Column(modifier = Modifier.fillMaxWidth(.78f)) {
+                                Text(
+                                    text = track.title,
+                                    style = MaterialTheme.typography.titleMedium,
+                                    fontSize = 18.sp,
+                                    maxLines = 1,
+                                    overflow = TextOverflow.Ellipsis
+                                )
+
+                                Spacer(modifier = Modifier.height(6.dp))
+
+                                LazyRow(modifier = Modifier.fillMaxWidth()) {
+                                    track.trackArtists.forEachIndexed { index, trackArtist ->
+                                        item {
+                                            Text(
+                                                modifier = Modifier.clickable(
+                                                    onClick = { onClickArtist(trackArtist.artistHash) },
+                                                    indication = null,
+                                                    interactionSource = remember { MutableInteractionSource() }
+                                                ),
+                                                text = trackArtist.name,
+                                                maxLines = 1,
+                                                style = MaterialTheme.typography.bodySmall,
+                                                color = MaterialTheme.colorScheme.onSurface.copy(
+                                                    alpha = .84f
+                                                ),
+                                                overflow = TextOverflow.Ellipsis
+                                            )
+                                            if (index != track.trackArtists.lastIndex) {
+                                                Text(
+                                                    text = ", ",
+                                                    style = MaterialTheme.typography.bodySmall,
+                                                    color = MaterialTheme.colorScheme.onSurface.copy(
+                                                        alpha = .84f
+                                                    )
+                                                )
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+
+                            IconButton(
+                                modifier = Modifier.clip(CircleShape),
+                                onClick = { onToggleFavorite(track.isFavorite, track.trackHash) }
+                            ) {
+                                val icon = if (track.isFavorite) R.drawable.fav_filled
+                                else R.drawable.fav_not_filled
+                                Icon(
+                                    painter = painterResource(id = icon),
+                                    contentDescription = "Favorite"
+                                )
+                            }
+                        }
+
+                        Spacer(modifier = Modifier.height(28.dp))
+
+                        // Seek bar
+                        Column(modifier = Modifier.padding(horizontal = 24.dp)) {
+                            WavySlider(
+                                modifier = Modifier.height(12.dp),
+                                value = seekPosition,
+                                onValueChangeFinished = {},
+                                onValueChange = { value -> onSeekPlayBack(value) },
+                                waveLength = 32.dp,
+                                waveHeight = if (animateWave) 8.dp else 0.dp,
+                                waveVelocity = 16.dp to WaveDirection.HEAD,
+                                waveThickness = 4.dp,
+                                trackThickness = 4.dp,
+                                incremental = false,
+                                animationSpecs = WaveAnimationSpecs(
+                                    waveHeightAnimationSpec = tween(
+                                        durationMillis = 300,
+                                        easing = FastOutSlowInEasing
+                                    ),
+                                    waveVelocityAnimationSpec = tween(
+                                        durationMillis = 300,
+                                        easing = LinearOutSlowInEasing
+                                    ),
+                                    waveAppearanceAnimationSpec = tween(
+                                        durationMillis = 300,
+                                        easing = EaseOutQuad
+                                    )
+                                )
+                            )
+
+                            Spacer(modifier = Modifier.height(12.dp))
+
+                            Row(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .padding(horizontal = 4.dp),
+                                horizontalArrangement = Arrangement.SpaceBetween
+                            ) {
+                                Text(
+                                    text = playbackDuration,
+                                    style = MaterialTheme.typography.bodySmall,
+                                    color = MaterialTheme.colorScheme.onSurface.copy(alpha = .84f)
+                                )
+                                Text(
+                                    text = if (playbackState == PlaybackState.ERROR)
+                                        track.duration.formatDuration() else trackDuration,
+                                    style = MaterialTheme.typography.bodySmall,
+                                    color = MaterialTheme.colorScheme.onSurface.copy(alpha = .84f)
+                                )
+                            }
+                        }
+
+                        Spacer(modifier = Modifier.height(24.dp))
+
+                        // Playback controls
+                        Row(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(horizontal = 24.dp),
+                            verticalAlignment = Alignment.CenterVertically,
+                            horizontalArrangement = Arrangement.SpaceEvenly
+                        ) {
+                            IconButton(
+                                modifier = Modifier
+                                    .clip(CircleShape)
+                                    .background(
+                                        MaterialTheme.colorScheme.secondaryContainer.copy(alpha = .5f)
+                                    ),
+                                onClick = { onClickPrev() }
+                            ) {
+                                Icon(
+                                    painter = painterResource(id = R.drawable.prev),
+                                    contentDescription = "Previous"
+                                )
+                            }
+
+                            Box(
+                                modifier = Modifier.clickable(
+                                    indication = null,
+                                    interactionSource = remember { MutableInteractionSource() },
+                                    onClick = {
+                                        if (playbackState != PlaybackState.ERROR) {
+                                            onTogglePlayerState()
+                                        } else {
+                                            onResumePlayBackFromError()
+                                        }
+                                    }
+                                )
+                            ) {
+                                Box(
+                                    modifier = Modifier.wrapContentSize(),
+                                    contentAlignment = Alignment.Center
+                                ) {
+                                    if (playbackState == PlaybackState.ERROR) {
+                                        Icon(
+                                            modifier = Modifier
+                                                .padding(horizontal = 5.dp)
+                                                .size(70.dp),
+                                            painter = painterResource(id = playbackStateIcon),
+                                            tint = if (isBuffering)
+                                                MaterialTheme.colorScheme.onErrorContainer.copy(
+                                                    alpha = .25f
+                                                )
+                                            else
+                                                MaterialTheme.colorScheme.onErrorContainer.copy(
+                                                    alpha = .75f
+                                                ),
+                                            contentDescription = "Error state"
+                                        )
+                                    } else {
+                                        Box(
+                                            modifier = Modifier
+                                                .height(70.dp)
+                                                .width(80.dp)
+                                                .clip(RoundedCornerShape(32))
+                                                .background(MaterialTheme.colorScheme.secondaryContainer),
+                                            contentAlignment = Alignment.Center
+                                        ) {
+                                            Icon(
+                                                modifier = Modifier.size(44.dp),
+                                                tint = MaterialTheme.colorScheme.onSecondaryContainer,
+                                                painter = painterResource(id = playbackStateIcon),
+                                                contentDescription = "Play/Pause"
+                                            )
+                                        }
+                                    }
+
+                                    if (isBuffering) {
+                                        CircularProgressIndicator(
+                                            modifier = Modifier.size(50.dp),
+                                            strokeCap = StrokeCap.Round,
+                                            strokeWidth = 1.dp,
+                                            color = MaterialTheme.colorScheme.onSecondaryContainer
+                                        )
+                                    }
+                                }
+                            }
+
+                            IconButton(
+                                modifier = Modifier
+                                    .clip(CircleShape)
+                                    .background(
+                                        MaterialTheme.colorScheme.secondaryContainer.copy(alpha = .5f)
+                                    ),
+                                onClick = { onClickNext() }
+                            ) {
+                                Icon(
+                                    painter = painterResource(id = R.drawable.next),
+                                    tint = MaterialTheme.colorScheme.onSecondaryContainer,
+                                    contentDescription = "Next"
+                                )
+                            }
+                        }
+                    }
+
+                    // Bitrate badge
+                    Box(
+                        modifier = Modifier
+                            .clip(RoundedCornerShape(24))
+                            .background(
+                                if (isDarkTheme) fileTypeTextColor.copy(alpha = .075f)
+                                else fileTypeBadgeColor
+                            )
+                            .wrapContentSize()
+                            .padding(8.dp)
+                    ) {
+                        Row(verticalAlignment = Alignment.CenterVertically) {
+                            Text(
+                                text = fileType,
+                                style = MaterialTheme.typography.bodySmall,
+                                fontWeight = FontWeight.SemiBold,
+                                color = fileTypeTextColor
+                            )
+                            Text(
+                                text = " • ",
+                                style = MaterialTheme.typography.bodySmall,
+                                fontWeight = FontWeight.SemiBold,
+                                color = fileTypeTextColor
+                            )
+                            Text(
+                                text = "${track.bitrate} Kbps",
+                                style = MaterialTheme.typography.bodySmall,
+                                fontWeight = FontWeight.SemiBold,
+                                color = fileTypeTextColor
+                            )
+                        }
+                    }
+
+                    // Navigation and Control Icons
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .clip(RoundedCornerShape(topStart = 16.dp, topEnd = 16.dp))
+                            .background(MaterialTheme.colorScheme.inverseOnSurface)
+                            .navigationBarsPadding()
+                            .padding(vertical = 12.dp, horizontal = 32.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.SpaceBetween
+                    ) {
+                        IconButton(onClick = { onToggleRepeatMode() }) {
+                            Icon(
+                                painter = painterResource(id = repeatModeIcon),
+                                tint = if (repeatMode == RepeatMode.REPEAT_OFF)
+                                    MaterialTheme.colorScheme.onSurface.copy(alpha = .3f)
+                                else MaterialTheme.colorScheme.onSurface,
+                                contentDescription = "Repeat"
+                            )
+                        }
+
+                        // Queue icon - triggers queue sheet
+                        IconButton(onClick = {
+                            // Queue sheet will appear via drag from bottom zone
+                        }) {
+                            Icon(
+                                painter = painterResource(id = R.drawable.play_list),
+                                contentDescription = "Queue"
+                            )
+                        }
+
+                        IconButton(onClick = { onToggleShuffleMode() }) {
+                            Icon(
+                                painter = painterResource(id = R.drawable.shuffle),
+                                tint = if (shuffleMode == ShuffleMode.SHUFFLE_OFF)
+                                    MaterialTheme.colorScheme.onSurface.copy(alpha = .3f)
+                                else MaterialTheme.colorScheme.onSurface,
+                                contentDescription = "Shuffle"
+                            )
+                        }
+                    }
+                }
+            }
+        }
+
+        // Queue drag zone (only when primary sheet is expanded)
+        if (primarySheetProgress >= 0.95f) {
+            var lastDragOffset by remember { mutableFloatStateOf(queueSheetOffset.value) }
+            var isDraggingUp by remember { mutableStateOf(false) }
+
+            Box(
+                contentAlignment = Alignment.Center,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .weight(1f)
+                    .pointerInput(Unit) {
+                        detectDragGestures(
+                            onDragStart = { lastDragOffset = queueSheetOffset.value },
+                            onDragEnd = {
+                                coroutineScope.launch {
+                                    val queueSheetProgress =
+                                        (queueInitialOffset - queueSheetOffset.value) /
+                                                (queueInitialOffset - queueExpandedOffset)
+
+                                    val threshold = if (isDraggingUp) 0.20f else 0.90f
+
+                                    val targetOffset = if (queueSheetProgress > threshold) {
+                                        queueExpandedOffset
+                                    } else {
+                                        queueInitialOffset
+                                    }
+
+                                    queueSheetOffset.animateTo(
+                                        targetValue = targetOffset,
+                                        animationSpec = spring(
+                                            dampingRatio = 0.8f,
+                                            stiffness = 400f
+                                        )
+                                    )
+                                }
+                            }
+                        ) { _, dragAmount ->
+                            coroutineScope.launch {
+                                val newOffset = (queueSheetOffset.value + dragAmount.y)
+                                    .coerceIn(queueExpandedOffset, queueInitialOffset)
+
+                                isDraggingUp = newOffset < lastDragOffset
+                                lastDragOffset = newOffset
+
+                                queueSheetOffset.snapTo(newOffset)
+                            }
+                        }
+                    }
+            ) {
+                // Empty drag zone content
+            }
+        }
+    }
+    } // End of Box wrapper
+}
+
+/**
+ * Queue Sheet Overlay - Secondary sheet that appears when primary player is fully expanded.
+ *
+ * Behavior:
+ * - Draggable from bottom with spring animations
+ * - Direction-aware snapping (20% threshold up, 90% down)
+ * - Opacity based on drag progress
+ */
+@Composable
+private fun QueueSheetOverlay(
+    queue: List<Track>,
+    source: QueueSource,
+    playingTrackIndex: Int,
+    playingTrack: Track,
+    playbackState: PlaybackState,
+    baseUrl: String,
+    animatedOffset: Animatable<Float, AnimationVector1D>,
+    initialOffset: Float,
+    expandedOffset: Float,
+    onClickQueueItem: (Int) -> Unit,
+    onTogglePlayerState: () -> Unit
+) {
+    val configuration = LocalConfiguration.current
+    val density = LocalDensity.current
+    val coroutineScope = rememberCoroutineScope()
+    val screenHeightPx = with(density) { configuration.screenHeightDp.dp.toPx() }
+    val lazyColumnState = rememberLazyListState()
+
+    // Track drag direction
+    var lastOffset by remember { mutableFloatStateOf(animatedOffset.value) }
+    var isDraggingUp by remember { mutableStateOf(false) }
+
+    // Calculate drag progress
+    val queueProgress by remember {
+        derivedStateOf {
+            val progress = (initialOffset - animatedOffset.value) / (initialOffset - expandedOffset)
+            progress.coerceIn(0f, 1f)
+        }
+    }
+
+    // Opacity based on drag progress - reaches 1.0 at 50% drag
+    val queueOpacity by remember {
+        derivedStateOf {
+            (queueProgress / 0.5f).coerceIn(0f, 1f)
+        }
+    }
+
+    // Scroll to playing track when sheet opens
+    LaunchedEffect(queueProgress) {
+        if (queueProgress > 0.9f && (playingTrackIndex - 1) in queue.indices) {
+            lazyColumnState.scrollToItem(playingTrackIndex - 1)
+        }
+    }
+
+    // Main Queue Sheet Container
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .alpha(queueOpacity)
+            .offset { IntOffset(0, animatedOffset.value.roundToInt()) }
+            .pointerInput(Unit) {
+                detectDragGestures(
+                    onDragStart = { lastOffset = animatedOffset.value },
+                    onDragEnd = {
+                        coroutineScope.launch {
+                            val threshold = if (isDraggingUp) 0.20f else 0.90f
+                            val targetOffset = if (queueProgress > threshold) {
+                                expandedOffset
+                            } else {
+                                initialOffset
+                            }
+
+                            animatedOffset.animateTo(
+                                targetValue = targetOffset,
+                                animationSpec = spring(
+                                    dampingRatio = 0.8f,
+                                    stiffness = 400f
+                                )
+                            )
+                        }
+                    },
+                    onDrag = { _, dragAmount ->
+                        coroutineScope.launch {
+                            val newOffset = (animatedOffset.value + dragAmount.y)
+                                .coerceIn(expandedOffset, initialOffset)
+
+                            isDraggingUp = newOffset < lastOffset
+                            lastOffset = newOffset
+
+                            animatedOffset.snapTo(newOffset)
+                        }
+                    }
+                )
+            }
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(
+                    color = MaterialTheme.colorScheme.surface,
+                    shape = RoundedCornerShape(topStart = 24.dp, topEnd = 24.dp)
+                )
+                .padding(horizontal = 12.dp),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            // Drag handle
+            Spacer(modifier = Modifier.height(12.dp))
+            Box(
+                modifier = Modifier
+                    .width(32.dp)
+                    .height(4.dp)
+                    .background(
+                        color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.4f),
+                        shape = RoundedCornerShape(2.dp)
+                    )
+            )
+
+            Spacer(modifier = Modifier.height(16.dp))
+
+            // Header
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text(
+                    text = "Queue",
+                    style = MaterialTheme.typography.headlineMedium
+                )
+            }
+
+            Spacer(modifier = Modifier.height(8.dp))
+
+            // Currently playing track card
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clip(RoundedCornerShape(12.dp))
+                    .background(MaterialTheme.colorScheme.onSurface.copy(alpha = .14f))
+                    .clickable { onTogglePlayerState() }
+                    .padding(8.dp),
+                contentAlignment = Alignment.CenterStart
+            ) {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.SpaceBetween
+                ) {
+                    Row(
+                        modifier = Modifier.fillMaxWidth(0.8f),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        AsyncImage(
+                            model = ImageRequest.Builder(LocalContext.current)
+                                .data("${baseUrl}img/thumbnail/small/${playingTrack.image}")
+                                .crossfade(true)
+                                .build(),
+                            placeholder = painterResource(R.drawable.audio_fallback),
+                            fallback = painterResource(R.drawable.audio_fallback),
+                            error = painterResource(R.drawable.audio_fallback),
+                            contentDescription = "Track Image",
+                            contentScale = ContentScale.Crop,
+                            modifier = Modifier
+                                .size(60.dp)
+                                .clip(RoundedCornerShape(6.dp))
+                        )
+
+                        Column(modifier = Modifier.padding(horizontal = 12.dp)) {
+                            Text(
+                                text = playingTrack.title,
+                                style = MaterialTheme.typography.bodyLarge,
+                                fontWeight = FontWeight.Bold,
+                                maxLines = 1,
+                                overflow = TextOverflow.Ellipsis
+                            )
+
+                            Spacer(modifier = Modifier.height(4.dp))
+
+                            Text(
+                                text = playingTrack.trackArtists.joinToString(", ") { it.name },
+                                color = MaterialTheme.colorScheme.onSurface.copy(alpha = .80f),
+                                style = MaterialTheme.typography.bodySmall,
+                                maxLines = 1,
+                                overflow = TextOverflow.Ellipsis
+                            )
+                        }
+                    }
+
+                    // Sound Bars
+                    Box(
+                        modifier = Modifier
+                            .size(50.dp)
+                            .padding(end = 8.dp)
+                    ) {
+                        SoundSignalBars(animate = playbackState == PlaybackState.PLAYING)
+                    }
+                }
+            }
+
+            Spacer(modifier = Modifier.height(8.dp))
+
+            // Queue items
+            LazyColumn(
+                state = lazyColumnState,
+                modifier = Modifier
+                    .weight(1f)
+                    .fillMaxWidth()
+            ) {
+                itemsIndexed(
+                    items = queue,
+                    key = { index, track -> "$index:${track.filepath}" }
+                ) { index, track ->
+                    TrackItem(
+                        track = track,
+                        playbackState = playbackState,
+                        isCurrentTrack = index == playingTrackIndex,
+                        baseUrl = baseUrl,
+                        showMenuIcon = false,
+                        onClickTrackItem = { onClickQueueItem(index) },
+                        onClickMoreVert = {}
+                    )
+
+                    if (index == queue.lastIndex) {
+                        Spacer(modifier = Modifier.height(80.dp))
+                    }
+                }
+            }
+        }
+    }
+}

--- a/feature/player/src/main/java/com/android/swingmusic/player/presentation/screen/AnimatedPlayerSheet.kt
+++ b/feature/player/src/main/java/com/android/swingmusic/player/presentation/screen/AnimatedPlayerSheet.kt
@@ -10,6 +10,9 @@ import androidx.compose.animation.core.EaseOutQuad
 import androidx.compose.animation.core.FastOutSlowInEasing
 import androidx.compose.animation.core.LinearOutSlowInEasing
 import androidx.compose.animation.core.VectorConverter
+import androidx.compose.animation.Crossfade
+import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.spring
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
@@ -77,6 +80,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.scale
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.StrokeCap
@@ -753,6 +757,7 @@ private fun AnimatedSheetContent(
                             modifier = Modifier.fillMaxWidth(),
                             horizontalAlignment = Alignment.CenterHorizontally
                         ) {
+
                             // Track title and artist
                             Row(
                                 modifier = Modifier
@@ -808,8 +813,27 @@ private fun AnimatedSheetContent(
                                     }
                                 }
 
+                                var heartBounce by remember { mutableStateOf(false) }
+                                val heartScale by animateFloatAsState(
+                                    targetValue = if (heartBounce) 1.3f else 1f,
+                                    animationSpec = spring(
+                                        dampingRatio = Spring.DampingRatioMediumBouncy,
+                                        stiffness = Spring.StiffnessMedium
+                                    ),
+                                    finishedListener = { heartBounce = false },
+                                    label = "heartScale"
+                                )
+
+                                LaunchedEffect(track.isFavorite) {
+                                    if (track.isFavorite) {
+                                        heartBounce = true
+                                    }
+                                }
+
                                 IconButton(
-                                    modifier = Modifier.clip(CircleShape),
+                                    modifier = Modifier
+                                        .scale(heartScale)
+                                        .clip(CircleShape),
                                     onClick = {
                                         onToggleFavorite(
                                             track.isFavorite,
@@ -817,12 +841,19 @@ private fun AnimatedSheetContent(
                                         )
                                     }
                                 ) {
-                                    val icon = if (track.isFavorite) R.drawable.fav_filled
-                                    else R.drawable.fav_not_filled
-                                    Icon(
-                                        painter = painterResource(id = icon),
-                                        contentDescription = "Favorite"
-                                    )
+                                    Crossfade(
+                                        targetState = track.isFavorite,
+                                        animationSpec = tween(200),
+                                        label = "heartCrossfade"
+                                    ) { isFavorite ->
+                                        Icon(
+                                            painter = painterResource(
+                                                id = if (isFavorite) R.drawable.fav_filled
+                                                else R.drawable.fav_not_filled
+                                            ),
+                                            contentDescription = "Favorite"
+                                        )
+                                    }
                                 }
                             }
 

--- a/feature/player/src/main/java/com/android/swingmusic/player/presentation/screen/AnimatedPlayerSheet.kt
+++ b/feature/player/src/main/java/com/android/swingmusic/player/presentation/screen/AnimatedPlayerSheet.kt
@@ -2,6 +2,7 @@
 
 package com.android.swingmusic.player.presentation.screen
 
+import androidx.activity.compose.BackHandler
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.AnimationVector1D
@@ -200,6 +201,21 @@ fun AnimatedPlayerSheet(
             val progress =
                 (queueInitialOffset - queueSheetOffset.value) / (queueInitialOffset - queueExpandedOffset)
             progress.coerceIn(0f, 1f)
+        }
+    }
+
+    // Handle back press: close queue sheet first, then collapse primary sheet
+    val isPrimarySheetExpanded = bottomSheetState.bottomSheetState.currentValue == SheetValue.Expanded
+    BackHandler(enabled = isQueueSheetOpen || isPrimarySheetExpanded) {
+        coroutineScope.launch {
+            if (isQueueSheetOpen) {
+                queueSheetOffset.animateTo(
+                    targetValue = queueInitialOffset,
+                    animationSpec = spring(dampingRatio = 0.8f, stiffness = 400f)
+                )
+            } else if (isPrimarySheetExpanded) {
+                bottomSheetState.bottomSheetState.partialExpand()
+            }
         }
     }
 

--- a/feature/player/src/main/java/com/android/swingmusic/player/presentation/screen/AnimatedPlayerSheet.kt
+++ b/feature/player/src/main/java/com/android/swingmusic/player/presentation/screen/AnimatedPlayerSheet.kt
@@ -140,7 +140,7 @@ import java.util.Locale
 import kotlin.math.pow
 import kotlin.math.roundToInt
 
-// Constants for sheet sizing (matching SheetDemo)
+// Constants for sheet sizing
 private val INITIAL_IMAGE_SIZE = 38.dp
 private val INITIAL_PADDING = 8.dp
 private val TOTAL_INITIAL_SIZE = INITIAL_IMAGE_SIZE + INITIAL_PADDING

--- a/feature/player/src/main/java/com/android/swingmusic/player/presentation/screen/NowPlaying.kt
+++ b/feature/player/src/main/java/com/android/swingmusic/player/presentation/screen/NowPlaying.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package com.android.swingmusic.player.presentation.screen
 
 import android.content.res.Configuration
@@ -598,7 +600,10 @@ private fun NowPlaying(
 /**
  * Expose a public Composable tied to MediaControllerViewModel
  * **/
-
+@Deprecated(
+    message = "Legacy NowPlayingScreen. Use AnimatedPlayerSheet instead.",
+    replaceWith = ReplaceWith("AnimatedPlayerSheet")
+)
 @Destination
 @Composable
 fun NowPlayingScreen(

--- a/feature/player/src/main/java/com/android/swingmusic/player/presentation/screen/Queue.kt
+++ b/feature/player/src/main/java/com/android/swingmusic/player/presentation/screen/Queue.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package com.android.swingmusic.player.presentation.screen
 
 import android.content.res.Configuration
@@ -412,7 +414,10 @@ private fun Queue(
 /**
  * A Composable that ties [Queue] to [MediaControllerViewModel] where its sates are hoisted
  * */
-
+@Deprecated(
+    message = "Legacy QueueScreen. Use AnimatedPlayerSheet with QueueSheetOverlay instead.",
+    replaceWith = ReplaceWith("AnimatedPlayerSheet")
+)
 @Destination
 @Composable
 fun QueueScreen(

--- a/feature/player/src/main/java/com/android/swingmusic/player/presentation/viewmodel/MediaControllerViewModel.kt
+++ b/feature/player/src/main/java/com/android/swingmusic/player/presentation/viewmodel/MediaControllerViewModel.kt
@@ -922,8 +922,6 @@ class MediaControllerViewModel @Inject constructor(
                         )
                     }
                 }
-
-                activateHapticResponse()
             }
         }
     }

--- a/feature/player/src/main/java/com/android/swingmusic/player/presentation/viewmodel/MediaControllerViewModel.kt
+++ b/feature/player/src/main/java/com/android/swingmusic/player/presentation/viewmodel/MediaControllerViewModel.kt
@@ -908,6 +908,19 @@ class MediaControllerViewModel @Inject constructor(
                     shuffledQueue.clear()
                     mediaController?.clearMediaItems()
                     trackToLog = null
+
+                    _playerUiState.update { currentState ->
+                        currentState.copy(
+                            nowPlayingTrack = null,
+                            queue = emptyList(),
+                            playingTrackIndex = 0,
+                            seekPosition = 0f,
+                            playbackDuration = "00:00",
+                            trackDuration = "00:00",
+                            isBuffering = false,
+                            playbackState = PlaybackState.PAUSED
+                        )
+                    }
                 }
 
                 activateHapticResponse()

--- a/feature/search/build.gradle.kts
+++ b/feature/search/build.gradle.kts
@@ -18,7 +18,7 @@ android {
 
     buildTypes {
         release {
-            isMinifyEnabled = true
+            isMinifyEnabled = false
         }
     }
     compileOptions {

--- a/feature/settings/build.gradle.kts
+++ b/feature/settings/build.gradle.kts
@@ -19,7 +19,7 @@ android {
 
     buildTypes {
         release {
-            isMinifyEnabled = true
+            isMinifyEnabled = false
         }
     }
     compileOptions {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -90,6 +90,7 @@ androidx-compose-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-
 androidx-compose-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
 androidx-compose-material3 = { group = "androidx.compose.material3", name = "material3" }
 androidx-compose-material-icons-extended = { group = "androidx.compose.material", name = "material-icons-extended" }
+androidx-compose-animation-graphics = { group = "androidx.compose.animation", name = "animation-graphics" }
 
 # Hilt
 hilt-android = { group = "com.google.dagger", name = "hilt-android", version.ref = "hilt" }

--- a/network/build.gradle.kts
+++ b/network/build.gradle.kts
@@ -17,7 +17,7 @@ android {
 
     buildTypes {
         release {
-            isMinifyEnabled = true
+            isMinifyEnabled = false
         }
     }
 

--- a/uicomponent/build.gradle.kts
+++ b/uicomponent/build.gradle.kts
@@ -46,6 +46,7 @@ dependencies {
     implementation(platform(libs.androidx.compose.bom))
     implementation(libs.androidx.compose.material3)
     api(libs.androidx.compose.material.icons.extended)
+    api(libs.androidx.compose.animation.graphics)
     implementation(libs.androidx.compose.ui)
     implementation(libs.androidx.compose.ui.tooling.preview)
 

--- a/uicomponent/build.gradle.kts
+++ b/uicomponent/build.gradle.kts
@@ -16,7 +16,7 @@ android {
 
     buildTypes {
         release {
-            isMinifyEnabled = true
+            isMinifyEnabled = false
         }
     }
     compileOptions {

--- a/uicomponent/src/main/java/com/android/swingmusic/uicomponent/presentation/component/CustomTrackBottomSheet.kt
+++ b/uicomponent/src/main/java/com/android/swingmusic/uicomponent/presentation/component/CustomTrackBottomSheet.kt
@@ -1,5 +1,10 @@
 package com.android.swingmusic.uicomponent.presentation.component
 
+import androidx.compose.animation.Crossfade
+import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.spring
+import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
@@ -25,6 +30,7 @@ import androidx.compose.material3.SheetState
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -32,6 +38,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.scale
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ColorMatrix
 import androidx.compose.ui.graphics.ColorMatrixColorFilter
@@ -95,15 +102,44 @@ fun CustomTrackBottomSheet(
                     Box(
                         modifier = Modifier.fillMaxWidth(), contentAlignment = Alignment.CenterEnd
                     ) {
-                        IconButton(modifier = Modifier.clip(CircleShape), onClick = {
-                            onToggleTrackFavorite(track.trackHash, track.isFavorite)
-                        }) {
-                            val icon = if (isFavorite) R.drawable.fav_filled
-                            else R.drawable.fav_not_filled
-                            Icon(
-                                painter = painterResource(id = icon),
-                                contentDescription = "Favorite"
-                            )
+                        var heartBounce by remember { mutableStateOf(false) }
+                        val heartScale by animateFloatAsState(
+                            targetValue = if (heartBounce) 1.3f else 1f,
+                            animationSpec = spring(
+                                dampingRatio = Spring.DampingRatioMediumBouncy,
+                                stiffness = Spring.StiffnessMedium
+                            ),
+                            finishedListener = { heartBounce = false },
+                            label = "heartScale"
+                        )
+
+                        LaunchedEffect(isFavorite) {
+                            if (isFavorite) {
+                                heartBounce = true
+                            }
+                        }
+
+                        IconButton(
+                            modifier = Modifier
+                                .scale(heartScale)
+                                .clip(CircleShape),
+                            onClick = {
+                                onToggleTrackFavorite(track.trackHash, track.isFavorite)
+                            }
+                        ) {
+                            Crossfade(
+                                targetState = isFavorite,
+                                animationSpec = tween(200),
+                                label = "heartCrossfade"
+                            ) { favorite ->
+                                Icon(
+                                    painter = painterResource(
+                                        id = if (favorite) R.drawable.fav_filled
+                                        else R.drawable.fav_not_filled
+                                    ),
+                                    contentDescription = "Favorite"
+                                )
+                            }
                         }
                     }
                 }

--- a/uicomponent/src/main/java/com/android/swingmusic/uicomponent/presentation/component/SoundSignalBars.kt
+++ b/uicomponent/src/main/java/com/android/swingmusic/uicomponent/presentation/component/SoundSignalBars.kt
@@ -31,7 +31,7 @@ fun SoundSignalBars(animate: Boolean) {
         initialHeights.map { mutableFloatStateOf(it) }
     }
 
-    LaunchedEffect(Unit) {
+    LaunchedEffect(animate) {
         if (animate) {
             while (true) {
                 barStates.forEach { barState ->

--- a/uicomponent/src/main/res/drawable/avd_album.xml
+++ b/uicomponent/src/main/res/drawable/avd_album.xml
@@ -1,0 +1,80 @@
+<animated-vector xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:aapt="http://schemas.android.com/aapt">
+    <aapt:attr name="android:drawable">
+        <vector
+            android:name="album_vector"
+            android:width="24dp"
+            android:height="24dp"
+            android:viewportWidth="24"
+            android:viewportHeight="24">
+            <group
+                android:name="scale_group"
+                android:pivotX="12"
+                android:pivotY="12"
+                android:scaleX="1"
+                android:scaleY="1">
+                <group
+                    android:name="rotate_group"
+                    android:pivotX="12"
+                    android:pivotY="12"
+                    android:rotation="0">
+                    <path
+                        android:name="album_path"
+                        android:fillColor="@android:color/white"
+                        android:pathData="M12,2C6.48,2 2,6.48 2,12s4.48,10 10,10 10,-4.48 10,-10S17.52,2 12,2zM12,16.5c-2.49,0 -4.5,-2.01 -4.5,-4.5S9.51,7.5 12,7.5s4.5,2.01 4.5,4.5 -2.01,4.5 -4.5,4.5zM12,11c-0.55,0 -1,0.45 -1,1s0.45,1 1,1 1,-0.45 1,-1 -0.45,-1 -1,-1z"/>
+                </group>
+            </group>
+        </vector>
+    </aapt:attr>
+    <target android:name="scale_group">
+        <aapt:attr name="android:animation">
+            <set android:ordering="sequentially">
+                <objectAnimator
+                    android:duration="200"
+                    android:propertyName="scaleX"
+                    android:valueFrom="1"
+                    android:valueTo="1.2"
+                    android:valueType="floatType"
+                    android:interpolator="@android:interpolator/fast_out_slow_in"/>
+                <objectAnimator
+                    android:duration="250"
+                    android:propertyName="scaleX"
+                    android:valueFrom="1.2"
+                    android:valueTo="1"
+                    android:valueType="floatType"
+                    android:interpolator="@android:interpolator/decelerate_cubic"/>
+            </set>
+        </aapt:attr>
+    </target>
+    <target android:name="scale_group">
+        <aapt:attr name="android:animation">
+            <set android:ordering="sequentially">
+                <objectAnimator
+                    android:duration="200"
+                    android:propertyName="scaleY"
+                    android:valueFrom="1"
+                    android:valueTo="1.2"
+                    android:valueType="floatType"
+                    android:interpolator="@android:interpolator/fast_out_slow_in"/>
+                <objectAnimator
+                    android:duration="250"
+                    android:propertyName="scaleY"
+                    android:valueFrom="1.2"
+                    android:valueTo="1"
+                    android:valueType="floatType"
+                    android:interpolator="@android:interpolator/decelerate_cubic"/>
+            </set>
+        </aapt:attr>
+    </target>
+    <target android:name="rotate_group">
+        <aapt:attr name="android:animation">
+            <objectAnimator
+                android:duration="450"
+                android:propertyName="rotation"
+                android:valueFrom="0"
+                android:valueTo="360"
+                android:valueType="floatType"
+                android:interpolator="@android:interpolator/fast_out_slow_in"/>
+        </aapt:attr>
+    </target>
+</animated-vector>

--- a/uicomponent/src/main/res/drawable/avd_artist.xml
+++ b/uicomponent/src/main/res/drawable/avd_artist.xml
@@ -1,0 +1,77 @@
+<animated-vector xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:aapt="http://schemas.android.com/aapt">
+    <aapt:attr name="android:drawable">
+        <vector
+            android:name="artist_vector"
+            android:width="24dp"
+            android:height="24dp"
+            android:viewportWidth="960"
+            android:viewportHeight="960">
+            <group
+                android:name="scale_group"
+                android:pivotX="480"
+                android:pivotY="480"
+                android:scaleX="1"
+                android:scaleY="1">
+                <path
+                    android:name="artist_path"
+                    android:fillColor="@android:color/white"
+                    android:pathData="M700,800Q658,800 629,771Q600,742 600,700Q600,658 629,629Q658,600 700,600Q708,600 718,601.5Q728,603 740,608L740,400L880,400L880,480L800,480L800,700Q800,742 771,771Q742,800 700,800ZM440,480Q374,480 327,433Q280,386 280,320Q280,254 327,207Q374,160 440,160Q506,160 553,207Q600,254 600,320Q600,386 553,433Q506,480 440,480ZM120,800L120,688Q120,653 137.5,625Q155,597 184,582Q246,551 310,535.5Q374,520 440,520Q482,520 523.5,526.5Q565,533 607,546Q541,586 525,660.5Q509,735 551,800L120,800Z"/>
+            </group>
+        </vector>
+    </aapt:attr>
+    <target android:name="scale_group">
+        <aapt:attr name="android:animation">
+            <set android:ordering="sequentially">
+                <objectAnimator
+                    android:duration="150"
+                    android:propertyName="scaleX"
+                    android:valueFrom="1"
+                    android:valueTo="0.85"
+                    android:valueType="floatType"
+                    android:interpolator="@android:interpolator/fast_out_slow_in"/>
+                <objectAnimator
+                    android:duration="300"
+                    android:propertyName="scaleX"
+                    android:valueFrom="0.85"
+                    android:valueTo="1.15"
+                    android:valueType="floatType"
+                    android:interpolator="@android:interpolator/overshoot"/>
+                <objectAnimator
+                    android:duration="150"
+                    android:propertyName="scaleX"
+                    android:valueFrom="1.15"
+                    android:valueTo="1"
+                    android:valueType="floatType"
+                    android:interpolator="@android:interpolator/decelerate_cubic"/>
+            </set>
+        </aapt:attr>
+    </target>
+    <target android:name="scale_group">
+        <aapt:attr name="android:animation">
+            <set android:ordering="sequentially">
+                <objectAnimator
+                    android:duration="150"
+                    android:propertyName="scaleY"
+                    android:valueFrom="1"
+                    android:valueTo="0.85"
+                    android:valueType="floatType"
+                    android:interpolator="@android:interpolator/fast_out_slow_in"/>
+                <objectAnimator
+                    android:duration="300"
+                    android:propertyName="scaleY"
+                    android:valueFrom="0.85"
+                    android:valueTo="1.15"
+                    android:valueType="floatType"
+                    android:interpolator="@android:interpolator/overshoot"/>
+                <objectAnimator
+                    android:duration="150"
+                    android:propertyName="scaleY"
+                    android:valueFrom="1.15"
+                    android:valueTo="1"
+                    android:valueType="floatType"
+                    android:interpolator="@android:interpolator/decelerate_cubic"/>
+            </set>
+        </aapt:attr>
+    </target>
+</animated-vector>

--- a/uicomponent/src/main/res/drawable/avd_artist.xml
+++ b/uicomponent/src/main/res/drawable/avd_artist.xml
@@ -13,10 +13,16 @@
                 android:pivotY="480"
                 android:scaleX="1"
                 android:scaleY="1">
-                <path
-                    android:name="artist_path"
-                    android:fillColor="@android:color/white"
-                    android:pathData="M700,800Q658,800 629,771Q600,742 600,700Q600,658 629,629Q658,600 700,600Q708,600 718,601.5Q728,603 740,608L740,400L880,400L880,480L800,480L800,700Q800,742 771,771Q742,800 700,800ZM440,480Q374,480 327,433Q280,386 280,320Q280,254 327,207Q374,160 440,160Q506,160 553,207Q600,254 600,320Q600,386 553,433Q506,480 440,480ZM120,800L120,688Q120,653 137.5,625Q155,597 184,582Q246,551 310,535.5Q374,520 440,520Q482,520 523.5,526.5Q565,533 607,546Q541,586 525,660.5Q509,735 551,800L120,800Z"/>
+                <group
+                    android:name="rotate_group"
+                    android:pivotX="480"
+                    android:pivotY="480"
+                    android:rotation="0">
+                    <path
+                        android:name="artist_path"
+                        android:fillColor="@android:color/white"
+                        android:pathData="M700,800Q658,800 629,771Q600,742 600,700Q600,658 629,629Q658,600 700,600Q708,600 718,601.5Q728,603 740,608L740,400L880,400L880,480L800,480L800,700Q800,742 771,771Q742,800 700,800ZM440,480Q374,480 327,433Q280,386 280,320Q280,254 327,207Q374,160 440,160Q506,160 553,207Q600,254 600,320Q600,386 553,433Q506,480 440,480ZM120,800L120,688Q120,653 137.5,625Q155,597 184,582Q246,551 310,535.5Q374,520 440,520Q482,520 523.5,526.5Q565,533 607,546Q541,586 525,660.5Q509,735 551,800L120,800Z"/>
+                </group>
             </group>
         </vector>
     </aapt:attr>
@@ -71,6 +77,26 @@
                     android:valueTo="1"
                     android:valueType="floatType"
                     android:interpolator="@android:interpolator/decelerate_cubic"/>
+            </set>
+        </aapt:attr>
+    </target>
+    <target android:name="rotate_group">
+        <aapt:attr name="android:animation">
+            <set android:ordering="sequentially">
+                <objectAnimator
+                    android:duration="200"
+                    android:propertyName="rotation"
+                    android:valueFrom="0"
+                    android:valueTo="-20"
+                    android:valueType="floatType"
+                    android:interpolator="@android:interpolator/fast_out_slow_in"/>
+                <objectAnimator
+                    android:duration="250"
+                    android:propertyName="rotation"
+                    android:valueFrom="-20"
+                    android:valueTo="0"
+                    android:valueType="floatType"
+                    android:interpolator="@android:interpolator/overshoot"/>
             </set>
         </aapt:attr>
     </target>

--- a/uicomponent/src/main/res/drawable/avd_folder.xml
+++ b/uicomponent/src/main/res/drawable/avd_folder.xml
@@ -1,0 +1,63 @@
+<animated-vector xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:aapt="http://schemas.android.com/aapt">
+    <aapt:attr name="android:drawable">
+        <vector
+            android:name="folder_vector"
+            android:width="24dp"
+            android:height="24dp"
+            android:viewportWidth="24"
+            android:viewportHeight="24">
+            <group
+                android:name="scale_group"
+                android:pivotX="12"
+                android:pivotY="12"
+                android:scaleX="1"
+                android:scaleY="1">
+                <path
+                    android:name="folder_path"
+                    android:fillColor="@android:color/white"
+                    android:pathData="M10,4H4c-1.1,0 -1.99,0.9 -1.99,2L2,18c0,1.1 0.9,2 2,2h16c1.1,0 2,-0.9 2,-2V8c0,-1.1 -0.9,-2 -2,-2h-8l-2,-2z"/>
+            </group>
+        </vector>
+    </aapt:attr>
+    <target android:name="scale_group">
+        <aapt:attr name="android:animation">
+            <set android:ordering="sequentially">
+                <objectAnimator
+                    android:duration="250"
+                    android:propertyName="scaleX"
+                    android:valueFrom="1"
+                    android:valueTo="1.25"
+                    android:valueType="floatType"
+                    android:interpolator="@android:interpolator/overshoot"/>
+                <objectAnimator
+                    android:duration="200"
+                    android:propertyName="scaleX"
+                    android:valueFrom="1.25"
+                    android:valueTo="1"
+                    android:valueType="floatType"
+                    android:interpolator="@android:interpolator/decelerate_cubic"/>
+            </set>
+        </aapt:attr>
+    </target>
+    <target android:name="scale_group">
+        <aapt:attr name="android:animation">
+            <set android:ordering="sequentially">
+                <objectAnimator
+                    android:duration="250"
+                    android:propertyName="scaleY"
+                    android:valueFrom="1"
+                    android:valueTo="1.25"
+                    android:valueType="floatType"
+                    android:interpolator="@android:interpolator/overshoot"/>
+                <objectAnimator
+                    android:duration="200"
+                    android:propertyName="scaleY"
+                    android:valueFrom="1.25"
+                    android:valueTo="1"
+                    android:valueType="floatType"
+                    android:interpolator="@android:interpolator/decelerate_cubic"/>
+            </set>
+        </aapt:attr>
+    </target>
+</animated-vector>

--- a/uicomponent/src/main/res/drawable/avd_heart.xml
+++ b/uicomponent/src/main/res/drawable/avd_heart.xml
@@ -1,0 +1,100 @@
+<animated-vector xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:aapt="http://schemas.android.com/aapt">
+    <aapt:attr name="android:drawable">
+        <vector
+            android:name="heart_vector"
+            android:width="24dp"
+            android:height="24dp"
+            android:viewportWidth="24"
+            android:viewportHeight="24">
+            <group
+                android:name="scale_group"
+                android:pivotX="12"
+                android:pivotY="12"
+                android:scaleX="1"
+                android:scaleY="1">
+                <path
+                    android:name="heart_path"
+                    android:fillColor="@android:color/white"
+                    android:pathData="M12,21.35l-1.45,-1.32C5.4,15.36 2,12.28 2,8.5 2,5.42 4.42,3 7.5,3c1.74,0 3.41,0.81 4.5,2.09C13.09,3.81 14.76,3 16.5,3 19.58,3 22,5.42 22,8.5c0,3.78 -3.4,6.86 -8.55,11.54L12,21.35z"/>
+            </group>
+        </vector>
+    </aapt:attr>
+    <!-- Heartbeat: scale up, down, up again, settle -->
+    <target android:name="scale_group">
+        <aapt:attr name="android:animation">
+            <set android:ordering="sequentially">
+                <!-- First beat - quick pulse up -->
+                <objectAnimator
+                    android:duration="100"
+                    android:propertyName="scaleX"
+                    android:valueFrom="1"
+                    android:valueTo="1.3"
+                    android:valueType="floatType"
+                    android:interpolator="@android:interpolator/accelerate_decelerate"/>
+                <!-- First beat - back down -->
+                <objectAnimator
+                    android:duration="100"
+                    android:propertyName="scaleX"
+                    android:valueFrom="1.3"
+                    android:valueTo="0.95"
+                    android:valueType="floatType"
+                    android:interpolator="@android:interpolator/decelerate_cubic"/>
+                <!-- Second beat - pulse up again -->
+                <objectAnimator
+                    android:duration="100"
+                    android:propertyName="scaleX"
+                    android:valueFrom="0.95"
+                    android:valueTo="1.2"
+                    android:valueType="floatType"
+                    android:interpolator="@android:interpolator/accelerate_decelerate"/>
+                <!-- Settle back to normal -->
+                <objectAnimator
+                    android:duration="150"
+                    android:propertyName="scaleX"
+                    android:valueFrom="1.2"
+                    android:valueTo="1"
+                    android:valueType="floatType"
+                    android:interpolator="@android:interpolator/overshoot"/>
+            </set>
+        </aapt:attr>
+    </target>
+    <target android:name="scale_group">
+        <aapt:attr name="android:animation">
+            <set android:ordering="sequentially">
+                <!-- First beat - quick pulse up -->
+                <objectAnimator
+                    android:duration="100"
+                    android:propertyName="scaleY"
+                    android:valueFrom="1"
+                    android:valueTo="1.3"
+                    android:valueType="floatType"
+                    android:interpolator="@android:interpolator/accelerate_decelerate"/>
+                <!-- First beat - back down -->
+                <objectAnimator
+                    android:duration="100"
+                    android:propertyName="scaleY"
+                    android:valueFrom="1.3"
+                    android:valueTo="0.95"
+                    android:valueType="floatType"
+                    android:interpolator="@android:interpolator/decelerate_cubic"/>
+                <!-- Second beat - pulse up again -->
+                <objectAnimator
+                    android:duration="100"
+                    android:propertyName="scaleY"
+                    android:valueFrom="0.95"
+                    android:valueTo="1.2"
+                    android:valueType="floatType"
+                    android:interpolator="@android:interpolator/accelerate_decelerate"/>
+                <!-- Settle back to normal -->
+                <objectAnimator
+                    android:duration="150"
+                    android:propertyName="scaleY"
+                    android:valueFrom="1.2"
+                    android:valueTo="1"
+                    android:valueType="floatType"
+                    android:interpolator="@android:interpolator/overshoot"/>
+            </set>
+        </aapt:attr>
+    </target>
+</animated-vector>

--- a/uicomponent/src/main/res/drawable/avd_heart_fill.xml
+++ b/uicomponent/src/main/res/drawable/avd_heart_fill.xml
@@ -1,0 +1,96 @@
+<animated-vector xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:aapt="http://schemas.android.com/aapt">
+    <aapt:attr name="android:drawable">
+        <vector
+            android:name="heart_vector"
+            android:width="24dp"
+            android:height="24dp"
+            android:viewportWidth="24"
+            android:viewportHeight="24">
+            <group
+                android:name="scale_group"
+                android:pivotX="12"
+                android:pivotY="12"
+                android:scaleX="1"
+                android:scaleY="1">
+                <!-- Outline heart (visible when not favorite) -->
+                <path
+                    android:name="outline_path"
+                    android:fillColor="@android:color/white"
+                    android:fillAlpha="1"
+                    android:pathData="M16.5,3c-1.74,0 -3.41,0.81 -4.5,2.09C10.91,3.81 9.24,3 7.5,3 4.42,3 2,5.42 2,8.5c0,3.78 3.4,6.86 8.55,11.54L12,21.35l1.45,-1.32C18.6,15.36 22,12.28 22,8.5 22,5.42 19.58,3 16.5,3zM12.1,18.55l-0.1,0.1 -0.1,-0.1C7.14,14.24 4,11.39 4,8.5 4,6.5 5.5,5 7.5,5c1.54,0 3.04,0.99 3.57,2.36h1.87C13.46,5.99 14.96,5 16.5,5c2,0 3.5,1.5 3.5,3.5 0,2.89 -3.14,5.74 -7.9,10.05z"/>
+                <!-- Filled heart (fades in when favorite) -->
+                <path
+                    android:name="filled_path"
+                    android:fillColor="@android:color/white"
+                    android:fillAlpha="0"
+                    android:pathData="M12,21.35l-1.45,-1.32C5.4,15.36 2,12.28 2,8.5 2,5.42 4.42,3 7.5,3c1.74,0 3.41,0.81 4.5,2.09C13.09,3.81 14.76,3 16.5,3 19.58,3 22,5.42 22,8.5c0,3.78 -3.4,6.86 -8.55,11.54L12,21.35z"/>
+            </group>
+        </vector>
+    </aapt:attr>
+    <!-- Fade out outline -->
+    <target android:name="outline_path">
+        <aapt:attr name="android:animation">
+            <objectAnimator
+                android:duration="150"
+                android:propertyName="fillAlpha"
+                android:valueFrom="1"
+                android:valueTo="0"
+                android:valueType="floatType"
+                android:interpolator="@android:interpolator/fast_out_slow_in"/>
+        </aapt:attr>
+    </target>
+    <!-- Fade in filled -->
+    <target android:name="filled_path">
+        <aapt:attr name="android:animation">
+            <objectAnimator
+                android:duration="150"
+                android:propertyName="fillAlpha"
+                android:valueFrom="0"
+                android:valueTo="1"
+                android:valueType="floatType"
+                android:interpolator="@android:interpolator/fast_out_slow_in"/>
+        </aapt:attr>
+    </target>
+    <!-- Scale bounce -->
+    <target android:name="scale_group">
+        <aapt:attr name="android:animation">
+            <set android:ordering="sequentially">
+                <objectAnimator
+                    android:duration="150"
+                    android:propertyName="scaleX"
+                    android:valueFrom="1"
+                    android:valueTo="1.3"
+                    android:valueType="floatType"
+                    android:interpolator="@android:interpolator/accelerate_decelerate"/>
+                <objectAnimator
+                    android:duration="200"
+                    android:propertyName="scaleX"
+                    android:valueFrom="1.3"
+                    android:valueTo="1"
+                    android:valueType="floatType"
+                    android:interpolator="@android:interpolator/overshoot"/>
+            </set>
+        </aapt:attr>
+    </target>
+    <target android:name="scale_group">
+        <aapt:attr name="android:animation">
+            <set android:ordering="sequentially">
+                <objectAnimator
+                    android:duration="150"
+                    android:propertyName="scaleY"
+                    android:valueFrom="1"
+                    android:valueTo="1.3"
+                    android:valueType="floatType"
+                    android:interpolator="@android:interpolator/accelerate_decelerate"/>
+                <objectAnimator
+                    android:duration="200"
+                    android:propertyName="scaleY"
+                    android:valueFrom="1.3"
+                    android:valueTo="1"
+                    android:valueType="floatType"
+                    android:interpolator="@android:interpolator/overshoot"/>
+            </set>
+        </aapt:attr>
+    </target>
+</animated-vector>

--- a/uicomponent/src/main/res/drawable/avd_next.xml
+++ b/uicomponent/src/main/res/drawable/avd_next.xml
@@ -1,0 +1,91 @@
+<animated-vector xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:aapt="http://schemas.android.com/aapt">
+    <aapt:attr name="android:drawable">
+        <vector
+            android:name="next_vector"
+            android:width="24dp"
+            android:height="24dp"
+            android:viewportWidth="24"
+            android:viewportHeight="24">
+            <group
+                android:name="translate_group"
+                android:translateX="0"
+                android:pivotX="12"
+                android:pivotY="12">
+                <group
+                    android:name="scale_group"
+                    android:pivotX="12"
+                    android:pivotY="12"
+                    android:scaleX="1"
+                    android:scaleY="1">
+                    <path
+                        android:name="next_path"
+                        android:fillColor="@android:color/white"
+                        android:pathData="M6,18l8.5,-6L6,6v12zM8,9.86L11.03,12 8,14.14L8,9.86zM16,6h2v12h-2z"/>
+                </group>
+            </group>
+        </vector>
+    </aapt:attr>
+    <!-- Shift right then back -->
+    <target android:name="translate_group">
+        <aapt:attr name="android:animation">
+            <set android:ordering="sequentially">
+                <objectAnimator
+                    android:duration="150"
+                    android:propertyName="translateX"
+                    android:valueFrom="0"
+                    android:valueTo="3"
+                    android:valueType="floatType"
+                    android:interpolator="@android:interpolator/fast_out_slow_in"/>
+                <objectAnimator
+                    android:duration="200"
+                    android:propertyName="translateX"
+                    android:valueFrom="3"
+                    android:valueTo="0"
+                    android:valueType="floatType"
+                    android:interpolator="@android:interpolator/overshoot"/>
+            </set>
+        </aapt:attr>
+    </target>
+    <!-- Scale bounce -->
+    <target android:name="scale_group">
+        <aapt:attr name="android:animation">
+            <set android:ordering="sequentially">
+                <objectAnimator
+                    android:duration="150"
+                    android:propertyName="scaleX"
+                    android:valueFrom="1"
+                    android:valueTo="0.85"
+                    android:valueType="floatType"
+                    android:interpolator="@android:interpolator/fast_out_slow_in"/>
+                <objectAnimator
+                    android:duration="200"
+                    android:propertyName="scaleX"
+                    android:valueFrom="0.85"
+                    android:valueTo="1"
+                    android:valueType="floatType"
+                    android:interpolator="@android:interpolator/overshoot"/>
+            </set>
+        </aapt:attr>
+    </target>
+    <target android:name="scale_group">
+        <aapt:attr name="android:animation">
+            <set android:ordering="sequentially">
+                <objectAnimator
+                    android:duration="150"
+                    android:propertyName="scaleY"
+                    android:valueFrom="1"
+                    android:valueTo="0.85"
+                    android:valueType="floatType"
+                    android:interpolator="@android:interpolator/fast_out_slow_in"/>
+                <objectAnimator
+                    android:duration="200"
+                    android:propertyName="scaleY"
+                    android:valueFrom="0.85"
+                    android:valueTo="1"
+                    android:valueType="floatType"
+                    android:interpolator="@android:interpolator/overshoot"/>
+            </set>
+        </aapt:attr>
+    </target>
+</animated-vector>

--- a/uicomponent/src/main/res/drawable/avd_pause_to_play.xml
+++ b/uicomponent/src/main/res/drawable/avd_pause_to_play.xml
@@ -1,0 +1,46 @@
+<animated-vector xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:aapt="http://schemas.android.com/aapt">
+    <aapt:attr name="android:drawable">
+        <vector
+            android:name="play_pause_vector"
+            android:width="24dp"
+            android:height="24dp"
+            android:viewportWidth="24"
+            android:viewportHeight="24">
+            <group android:name="icon_group"
+                android:pivotX="12"
+                android:pivotY="12">
+                <path
+                    android:name="left_path"
+                    android:fillColor="@android:color/white"
+                    android:pathData="M8,5 L8,19 L8,19 L8,5 Z"/>
+                <path
+                    android:name="right_path"
+                    android:fillColor="@android:color/white"
+                    android:pathData="M8,5 L8,19 L19,12 L19,12 Z"/>
+            </group>
+        </vector>
+    </aapt:attr>
+    <target android:name="left_path">
+        <aapt:attr name="android:animation">
+            <objectAnimator
+                android:duration="300"
+                android:propertyName="pathData"
+                android:valueFrom="M8,5 L8,19 L8,19 L8,5 Z"
+                android:valueTo="M6,4 L6,20 L10,20 L10,4 Z"
+                android:valueType="pathType"
+                android:interpolator="@android:interpolator/fast_out_slow_in"/>
+        </aapt:attr>
+    </target>
+    <target android:name="right_path">
+        <aapt:attr name="android:animation">
+            <objectAnimator
+                android:duration="300"
+                android:propertyName="pathData"
+                android:valueFrom="M8,5 L8,19 L19,12 L19,12 Z"
+                android:valueTo="M14,4 L14,20 L18,20 L18,4 Z"
+                android:valueType="pathType"
+                android:interpolator="@android:interpolator/fast_out_slow_in"/>
+        </aapt:attr>
+    </target>
+</animated-vector>

--- a/uicomponent/src/main/res/drawable/avd_play_pause.xml
+++ b/uicomponent/src/main/res/drawable/avd_play_pause.xml
@@ -1,0 +1,51 @@
+<animated-vector xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:aapt="http://schemas.android.com/aapt">
+    <aapt:attr name="android:drawable">
+        <vector
+            android:name="play_pause_vector"
+            android:width="24dp"
+            android:height="24dp"
+            android:viewportWidth="24"
+            android:viewportHeight="24">
+            <group
+                android:name="icon_group"
+                android:pivotX="12"
+                android:pivotY="12">
+                <!-- Left half of play triangle / Left pause bar -->
+                <path
+                    android:name="left_path"
+                    android:fillColor="@android:color/white"
+                    android:pathData="M8,5 L12,7.5 L12,16.5 L8,19 Z"/>
+                <!-- Right half of play triangle / Right pause bar -->
+                <path
+                    android:name="right_path"
+                    android:fillColor="@android:color/white"
+                    android:pathData="M12,7.5 L19,12 L12,16.5 L12,12 Z"/>
+            </group>
+        </vector>
+    </aapt:attr>
+    <!-- Morph left path: left triangle half -> left pause bar -->
+    <target android:name="left_path">
+        <aapt:attr name="android:animation">
+            <objectAnimator
+                android:duration="300"
+                android:propertyName="pathData"
+                android:valueFrom="M8,5 L12,7.5 L12,16.5 L8,19 Z"
+                android:valueTo="M6,5 L10,5 L10,19 L6,19 Z"
+                android:valueType="pathType"
+                android:interpolator="@android:interpolator/fast_out_slow_in"/>
+        </aapt:attr>
+    </target>
+    <!-- Morph right path: right triangle half -> right pause bar -->
+    <target android:name="right_path">
+        <aapt:attr name="android:animation">
+            <objectAnimator
+                android:duration="300"
+                android:propertyName="pathData"
+                android:valueFrom="M12,7.5 L19,12 L12,16.5 L12,12 Z"
+                android:valueTo="M14,5 L18,5 L18,19 L14,19 Z"
+                android:valueType="pathType"
+                android:interpolator="@android:interpolator/fast_out_slow_in"/>
+        </aapt:attr>
+    </target>
+</animated-vector>

--- a/uicomponent/src/main/res/drawable/avd_play_to_pause.xml
+++ b/uicomponent/src/main/res/drawable/avd_play_to_pause.xml
@@ -1,0 +1,46 @@
+<animated-vector xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:aapt="http://schemas.android.com/aapt">
+    <aapt:attr name="android:drawable">
+        <vector
+            android:name="play_pause_vector"
+            android:width="24dp"
+            android:height="24dp"
+            android:viewportWidth="24"
+            android:viewportHeight="24">
+            <group android:name="icon_group"
+                android:pivotX="12"
+                android:pivotY="12">
+                <path
+                    android:name="left_path"
+                    android:fillColor="@android:color/white"
+                    android:pathData="M6,4 L6,20 L10,20 L10,4 Z"/>
+                <path
+                    android:name="right_path"
+                    android:fillColor="@android:color/white"
+                    android:pathData="M14,4 L14,20 L18,20 L18,4 Z"/>
+            </group>
+        </vector>
+    </aapt:attr>
+    <target android:name="left_path">
+        <aapt:attr name="android:animation">
+            <objectAnimator
+                android:duration="300"
+                android:propertyName="pathData"
+                android:valueFrom="M6,4 L6,20 L10,20 L10,4 Z"
+                android:valueTo="M8,5 L8,19 L8,19 L8,5 Z"
+                android:valueType="pathType"
+                android:interpolator="@android:interpolator/fast_out_slow_in"/>
+        </aapt:attr>
+    </target>
+    <target android:name="right_path">
+        <aapt:attr name="android:animation">
+            <objectAnimator
+                android:duration="300"
+                android:propertyName="pathData"
+                android:valueFrom="M14,4 L14,20 L18,20 L18,4 Z"
+                android:valueTo="M8,5 L8,19 L19,12 L19,12 Z"
+                android:valueType="pathType"
+                android:interpolator="@android:interpolator/fast_out_slow_in"/>
+        </aapt:attr>
+    </target>
+</animated-vector>

--- a/uicomponent/src/main/res/drawable/avd_prev.xml
+++ b/uicomponent/src/main/res/drawable/avd_prev.xml
@@ -1,0 +1,91 @@
+<animated-vector xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:aapt="http://schemas.android.com/aapt">
+    <aapt:attr name="android:drawable">
+        <vector
+            android:name="prev_vector"
+            android:width="24dp"
+            android:height="24dp"
+            android:viewportWidth="24"
+            android:viewportHeight="24">
+            <group
+                android:name="translate_group"
+                android:translateX="0"
+                android:pivotX="12"
+                android:pivotY="12">
+                <group
+                    android:name="scale_group"
+                    android:pivotX="12"
+                    android:pivotY="12"
+                    android:scaleX="1"
+                    android:scaleY="1">
+                    <path
+                        android:name="prev_path"
+                        android:fillColor="@android:color/white"
+                        android:pathData="M6,6h2v12L6,18zM9.5,12l8.5,6L18,6l-8.5,6zM16,14.14L12.97,12 16,9.86v4.28z"/>
+                </group>
+            </group>
+        </vector>
+    </aapt:attr>
+    <!-- Shift left then back -->
+    <target android:name="translate_group">
+        <aapt:attr name="android:animation">
+            <set android:ordering="sequentially">
+                <objectAnimator
+                    android:duration="150"
+                    android:propertyName="translateX"
+                    android:valueFrom="0"
+                    android:valueTo="-3"
+                    android:valueType="floatType"
+                    android:interpolator="@android:interpolator/fast_out_slow_in"/>
+                <objectAnimator
+                    android:duration="200"
+                    android:propertyName="translateX"
+                    android:valueFrom="-3"
+                    android:valueTo="0"
+                    android:valueType="floatType"
+                    android:interpolator="@android:interpolator/overshoot"/>
+            </set>
+        </aapt:attr>
+    </target>
+    <!-- Scale bounce -->
+    <target android:name="scale_group">
+        <aapt:attr name="android:animation">
+            <set android:ordering="sequentially">
+                <objectAnimator
+                    android:duration="150"
+                    android:propertyName="scaleX"
+                    android:valueFrom="1"
+                    android:valueTo="0.85"
+                    android:valueType="floatType"
+                    android:interpolator="@android:interpolator/fast_out_slow_in"/>
+                <objectAnimator
+                    android:duration="200"
+                    android:propertyName="scaleX"
+                    android:valueFrom="0.85"
+                    android:valueTo="1"
+                    android:valueType="floatType"
+                    android:interpolator="@android:interpolator/overshoot"/>
+            </set>
+        </aapt:attr>
+    </target>
+    <target android:name="scale_group">
+        <aapt:attr name="android:animation">
+            <set android:ordering="sequentially">
+                <objectAnimator
+                    android:duration="150"
+                    android:propertyName="scaleY"
+                    android:valueFrom="1"
+                    android:valueTo="0.85"
+                    android:valueType="floatType"
+                    android:interpolator="@android:interpolator/fast_out_slow_in"/>
+                <objectAnimator
+                    android:duration="200"
+                    android:propertyName="scaleY"
+                    android:valueFrom="0.85"
+                    android:valueTo="1"
+                    android:valueType="floatType"
+                    android:interpolator="@android:interpolator/overshoot"/>
+            </set>
+        </aapt:attr>
+    </target>
+</animated-vector>

--- a/uicomponent/src/main/res/drawable/avd_search.xml
+++ b/uicomponent/src/main/res/drawable/avd_search.xml
@@ -1,0 +1,89 @@
+<animated-vector xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:aapt="http://schemas.android.com/aapt">
+    <aapt:attr name="android:drawable">
+        <vector
+            android:name="search_vector"
+            android:width="24dp"
+            android:height="24dp"
+            android:viewportWidth="24"
+            android:viewportHeight="24">
+            <group
+                android:name="scale_group"
+                android:pivotX="12"
+                android:pivotY="12"
+                android:scaleX="1"
+                android:scaleY="1">
+                <group
+                    android:name="rotate_group"
+                    android:pivotX="9.5"
+                    android:pivotY="9.5"
+                    android:rotation="0">
+                    <path
+                        android:name="search_path"
+                        android:fillColor="@android:color/white"
+                        android:pathData="M15.5,14h-0.79l-0.28,-0.27C15.41,12.59 16,11.11 16,9.5 16,5.91 13.09,3 9.5,3S3,5.91 3,9.5 5.91,16 9.5,16c1.61,0 3.09,-0.59 4.23,-1.57l0.27,0.28v0.79l5,4.99L20.49,19l-4.99,-5zM9.5,14C7.01,14 5,11.99 5,9.5S7.01,5 9.5,5 14,7.01 14,9.5 11.99,14 9.5,14z"/>
+                </group>
+            </group>
+        </vector>
+    </aapt:attr>
+    <target android:name="scale_group">
+        <aapt:attr name="android:animation">
+            <set android:ordering="sequentially">
+                <objectAnimator
+                    android:duration="250"
+                    android:propertyName="scaleX"
+                    android:valueFrom="1"
+                    android:valueTo="1.25"
+                    android:valueType="floatType"
+                    android:interpolator="@android:interpolator/overshoot"/>
+                <objectAnimator
+                    android:duration="200"
+                    android:propertyName="scaleX"
+                    android:valueFrom="1.25"
+                    android:valueTo="1"
+                    android:valueType="floatType"
+                    android:interpolator="@android:interpolator/decelerate_cubic"/>
+            </set>
+        </aapt:attr>
+    </target>
+    <target android:name="scale_group">
+        <aapt:attr name="android:animation">
+            <set android:ordering="sequentially">
+                <objectAnimator
+                    android:duration="250"
+                    android:propertyName="scaleY"
+                    android:valueFrom="1"
+                    android:valueTo="1.25"
+                    android:valueType="floatType"
+                    android:interpolator="@android:interpolator/overshoot"/>
+                <objectAnimator
+                    android:duration="200"
+                    android:propertyName="scaleY"
+                    android:valueFrom="1.25"
+                    android:valueTo="1"
+                    android:valueType="floatType"
+                    android:interpolator="@android:interpolator/decelerate_cubic"/>
+            </set>
+        </aapt:attr>
+    </target>
+    <target android:name="rotate_group">
+        <aapt:attr name="android:animation">
+            <set android:ordering="sequentially">
+                <objectAnimator
+                    android:duration="200"
+                    android:propertyName="rotation"
+                    android:valueFrom="0"
+                    android:valueTo="-20"
+                    android:valueType="floatType"
+                    android:interpolator="@android:interpolator/fast_out_slow_in"/>
+                <objectAnimator
+                    android:duration="250"
+                    android:propertyName="rotation"
+                    android:valueFrom="-20"
+                    android:valueTo="0"
+                    android:valueType="floatType"
+                    android:interpolator="@android:interpolator/overshoot"/>
+            </set>
+        </aapt:attr>
+    </target>
+</animated-vector>


### PR DESCRIPTION
https://github.com/user-attachments/assets/42848531-8795-4c35-a1f5-fb84c7615bb2


### Core Feature

  - Created AnimatedPlayerSheet - a new player UI that smoothly animates from a mini-player to a full-screen player... bug fixes will be done in due time.
  - Added a secondary queue sheet accessible from the expanded player
  - Replaced the previous mini-player and NowPlayingScreen with this unified component

  ### Player Interactions

  - Horizontal swiping on mini-player to skip tracks
  - Back button handling (closes queue → collapses player)
  - Queue sheet can be opened via icon click or drag gesture
  - Queue now shows source (Album/Artist/Folder) with navigation links

  ### Animations

  - Animated vector drawables for play/pause, next, previous buttons
  - Heart icon animations (bounce + crossfade for favorites)
  - Bottom navigation animated icons (Folder, Album, Artist, Search)
  - Smooth artwork scaling, corner radius, and background blur transitions

  ### Polish

  - Locked orientation to portrait mode
  - Fixed folder empty state showing during loading errors
  - Improved image quality by loading original size cover art
  - Various UI refinements for drag responsiveness and visibility thresholds