### PR TITLE
fix: remember scroll position per folder (#104)

### DIFF
--- a/feature/folder/src/main/java/com/android/swingmusic/folder/presentation/screen/FoldersAndTracks.kt
+++ b/feature/folder/src/main/java/com/android/swingmusic/folder/presentation/screen/FoldersAndTracks.kt
@@ -39,6 +39,10 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshotFlow
+import kotlinx.coroutines.flow.drop
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.first
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.StrokeCap
@@ -90,7 +94,9 @@ private fun FoldersAndTracks(
     onGotoArtist: (hash: String) -> Unit,
     baseUrl: String,
     isManualRefreshing: Boolean,
-    onManualRefreshingChange: (Boolean) -> Unit
+    onManualRefreshingChange: (Boolean) -> Unit,
+    getSavedScroll: (path: String) -> Pair<Int, Int>?,
+    onSaveScroll: (path: String, index: Int, offset: Int) -> Unit
 ) {
     val sheetState = rememberModalBottomSheetState()
     val scope = rememberCoroutineScope()
@@ -134,6 +140,25 @@ private fun FoldersAndTracks(
 
     val lazyColumnState = rememberLazyListState()
     val pathsLazyRowState = rememberLazyListState()
+
+    LaunchedEffect(currentFolder.path) {
+        val saved = getSavedScroll(currentFolder.path)
+        if (saved != null) {
+            snapshotFlow { lazyColumnState.layoutInfo.totalItemsCount }
+                .filter { it > 0 }
+                .first()
+            lazyColumnState.scrollToItem(saved.first, saved.second)
+        }
+
+        snapshotFlow {
+            lazyColumnState.firstVisibleItemIndex to lazyColumnState.firstVisibleItemScrollOffset
+        }
+            .drop(1)
+            .collect { (index, offset) ->
+                onSaveScroll(currentFolder.path, index, offset)
+            }
+    }
+
     Scaffold { it ->
         PullToRefreshBox(
             modifier = Modifier.fillMaxSize(),
@@ -654,7 +679,11 @@ fun FoldersAndTracksScreen(
             onGotoArtist = { hash ->
                 navigator.gotoArtistInfo(hash)
             },
-            baseUrl = baseUrl ?: ""
+            baseUrl = baseUrl ?: "",
+            getSavedScroll = { path -> foldersViewModel.getScrollPosition(path) },
+            onSaveScroll = { path, index, offset ->
+                foldersViewModel.saveScrollPosition(path, index, offset)
+            }
         )
     }
 }

--- a/feature/folder/src/main/java/com/android/swingmusic/folder/presentation/viewmodel/FoldersViewModel.kt
+++ b/feature/folder/src/main/java/com/android/swingmusic/folder/presentation/viewmodel/FoldersViewModel.kt
@@ -68,6 +68,17 @@ class FoldersViewModel @Inject constructor(
         mutableStateOf(FoldersContentPagingState())
     val foldersContentPaging: State<FoldersContentPagingState> = _foldersContentPaging
 
+    private val folderScrollPositions = mutableMapOf<String, Pair<Int, Int>>()
+
+    private fun normalizeFolderPath(path: String): String = path.trimEnd('/')
+
+    fun saveScrollPosition(path: String, index: Int, offset: Int) {
+        folderScrollPositions[normalizeFolderPath(path)] = index to offset
+    }
+
+    fun getScrollPosition(path: String): Pair<Int, Int>? =
+        folderScrollPositions[normalizeFolderPath(path)]
+
     init {
         getFoldersContentPaging(homeDir.path)
     }


### PR DESCRIPTION
Closes #104.

When navigating in/out of nested folders, the screen now restores the scroll position the user left, per folder path. Each folder remembers its own position so deep trees feel natural to navigate.

## How it works

`FoldersViewModel` holds a `Map<String, (index, offset)>` keyed by folder path. The `FoldersAndTracks` composable runs a `LaunchedEffect` on `currentFolder.path` that:

1. Looks up the saved position for the path.
2. If found, waits until the lazy column has at least one item rendered, then `scrollToItem(index, offset)`.
3. Then starts collecting scroll changes from `lazyColumnState` and saves them back through the VM.

The order matters. If save monitoring started immediately, the initial `(0, 0)` from the freshly-rebuilt paging source would overwrite the real saved value before we could restore it. `.drop(1)` on the snapshotFlow skips that first emission.

## Path normalization

`Folder.path` carries a trailing slash for some paths (`/home/cwilvx/Music/`) and not for others (`/home/cwilvx/Music`). The VM already trims trailing slashes when matching breadcrumb entries, but the raw `Folder.path` on `_currentFolder` varies depending on entry path. Without normalization in our scroll map the same folder would key two entries, and a back-nav would miss the save. The fix calls `trimEnd('/')` on both save and lookup.

## Tested on Pixel 7 Pro

Verified all the cases:

- Scroll deep in a folder, enter a subfolder, back. Restores.
- Multi-level: A → A/B → A/B/C, then back-back-back. Each level restores its own position.
- Switch tabs (Folders → Albums → Folders). Position survives.
- Mixed breadcrumb back-nav + tap-album-then-back. Both paths use the same map.

Diag logs during dev confirmed each `restore start` had the right `(index, offset)` and `restore done` fired immediately after items loaded.