### PR TITLE
add MVI screen pattern skill and ObserverAsEvent helper

### DIFF
--- a/.claude/skills/mvi-screen.md
+++ b/.claude/skills/mvi-screen.md
@@ -1,0 +1,205 @@
+---
+description: Build swingmx screens using the standard MVI pattern. Screen + ScreenContent + ViewModel + UiState + UiEvent + UiEffect. Initial fetches go in VM init {}. One-shot effects flow through a Channel and are collected with ObserverAsEvent.
+---
+
+# MVI screen pattern
+
+Use this for any new screen, or when refactoring an existing screen.
+
+## File layout
+
+For a screen called `Foo` in feature module `feature/<area>`:
+
+```
+feature/<area>/src/main/java/com/android/swingmusic/<area>/presentation/
+  event/FooUiEvent.kt
+  event/FooUiEffect.kt   (or keep effects in their own folder if you prefer)
+  state/FooUiState.kt
+  screen/FooScreen.kt
+  viewmodel/FooViewModel.kt
+```
+
+## UiState
+
+`@Immutable data class`. Per-resource fields: `isLoadingX`, `errorLoadingX`, the data. Sheet / dialog visibility flags. `isRefreshing: Boolean`.
+
+```kotlin
+@Immutable
+internal data class FooUiState(
+    val isRefreshing: Boolean = false,
+
+    val isLoadingResource1: Boolean = false,
+    val errorLoadingResource1: String? = null,
+    val resource1: Resource1? = null,
+
+    val showSomethingSheet: Boolean = false,
+)
+```
+
+## UiEvent
+
+`sealed interface`. One object / data class per user action.
+
+```kotlin
+internal sealed interface FooUiEvent {
+    data object OnBackPressed : FooUiEvent
+    data object OnRefresh : FooUiEvent
+    data class OnItemClicked(val id: Int) : FooUiEvent
+}
+```
+
+## UiEffect
+
+`sealed class`. One-shot effects only (navigation, snackbar, toast, vibration, etc.). Never put state-shaped data here, that belongs in `UiState`.
+
+```kotlin
+internal sealed class FooUiEffect {
+    data class ShowSnackBar(val message: String) : FooUiEffect()
+    data class ShowToast(val message: String) : FooUiEffect()
+    data object NavigateBack : FooUiEffect()
+    data class NavigateToBar(val id: Int) : FooUiEffect()
+}
+```
+
+## ViewModel
+
+Rules:
+
+- `MutableStateFlow<UiState>` exposed as `asStateFlow()`.
+- `Channel<UiEffect>(Channel.UNLIMITED)` exposed as `receiveAsFlow()`.
+- `SavedStateHandle` for route args.
+- **`init { }` runs the initial fetches.** Not a `LaunchedEffect` in the screen.
+- Single `onEvent(event)` entry point with a `when` block.
+- Public `refresh()` for pull-to-refresh, which re-runs the same fetches with `isRefreshing = true`.
+- Private `updateUiState { copy(...) }` helper to keep call sites short.
+
+```kotlin
+@HiltViewModel
+internal class FooViewModel @Inject constructor(
+    private val getResource1UseCase: GetResource1UseCase,
+    savedStateHandle: SavedStateHandle,
+) : ViewModel() {
+    private val idFromNav: Int = savedStateHandle.get<Int>("id") ?: -1
+
+    private val _uiState = MutableStateFlow(FooUiState())
+    val uiState = _uiState.asStateFlow()
+
+    private val _uiEffect = Channel<FooUiEffect>(capacity = Channel.UNLIMITED)
+    val uiEffect = _uiEffect.receiveAsFlow()
+
+    init {
+        getResource1()
+    }
+
+    fun onEvent(event: FooUiEvent) {
+        when (event) {
+            FooUiEvent.OnBackPressed -> _uiEffect.trySend(FooUiEffect.NavigateBack)
+            FooUiEvent.OnRefresh -> refresh()
+            is FooUiEvent.OnItemClicked -> _uiEffect.trySend(FooUiEffect.NavigateToBar(event.id))
+        }
+    }
+
+    fun refresh() {
+        getResource1(isRefreshing = true)
+    }
+
+    private fun getResource1(isRefreshing: Boolean = false) {
+        updateUiState {
+            copy(
+                isRefreshing = isRefreshing,
+                isLoadingResource1 = !isRefreshing,
+                errorLoadingResource1 = null,
+            )
+        }
+        viewModelScope.launch {
+            // call use case, update state with result
+        }
+    }
+
+    private fun updateUiState(block: FooUiState.() -> FooUiState) {
+        _uiState.update(block)
+    }
+}
+```
+
+## Screen
+
+- Inject VM via `hiltViewModel()`.
+- Collect `uiState` with `collectAsState()`.
+- Collect `uiEffect` with `ObserverAsEvent(viewModel.uiEffect) { ... }`. Never raw `LaunchedEffect { uiEffect.collect { } }`.
+- Delegate UI to a stateless `ScreenContent`.
+- **No `LaunchedEffect` for initial data fetches.** The VM `init { }` handles it.
+
+```kotlin
+@Destination
+@Composable
+internal fun FooScreen(
+    navigator: FooNavigator,
+    modifier: Modifier = Modifier,
+    viewModel: FooViewModel = hiltViewModel(),
+) {
+    val uiState by viewModel.uiState.collectAsState()
+    val context = LocalContext.current
+    val scope = rememberCoroutineScope()
+    val snackbarHostState = remember { SnackbarHostState() }
+
+    ObserverAsEvent(viewModel.uiEffect) { effect ->
+        when (effect) {
+            is FooUiEffect.ShowSnackBar -> scope.launch {
+                snackbarHostState.showSnackbar(effect.message)
+            }
+            is FooUiEffect.ShowToast -> Toast.makeText(
+                context, effect.message, Toast.LENGTH_SHORT
+            ).show()
+            FooUiEffect.NavigateBack -> navigator.popBackStack()
+            is FooUiEffect.NavigateToBar -> navigator.goToBar(effect.id)
+        }
+    }
+
+    FooScreenContent(
+        uiState = uiState,
+        onEvent = viewModel::onEvent,
+        snackbarHost = { SnackbarHost(snackbarHostState) },
+        modifier = modifier,
+    )
+}
+
+@Composable
+private fun FooScreenContent(
+    uiState: FooUiState,
+    onEvent: (FooUiEvent) -> Unit,
+    snackbarHost: @Composable () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    // stateless UI here. previewable.
+}
+
+@Preview
+@Composable
+private fun FooScreenContentPreview() {
+    SwingMusicTheme {
+        FooScreenContent(
+            uiState = FooUiState(/* sample state */),
+            onEvent = {},
+            snackbarHost = {},
+        )
+    }
+}
+```
+
+## ObserverAsEvent
+
+Lives at `uicomponent/src/main/java/com/android/swingmusic/uicomponent/presentation/util/ObserverAsEvent.kt`. Always use this for one-shot effect collection. It ties collection to the STARTED lifecycle state (so effects don't fire while the screen is hidden) and uses `Dispatchers.Main.immediate` so navigation feels synchronous.
+
+```kotlin
+import com.android.swingmusic.uicomponent.presentation.util.ObserverAsEvent
+```
+
+## Don'ts
+
+- No `LaunchedEffect` in the Screen for initial data fetches. Use VM `init { }`.
+- No `loadedInitialData` flag. The VM lifecycle handles it.
+- No raw `LaunchedEffect { uiEffect.collect { } }`. Use `ObserverAsEvent`.
+- No `@Preview` on the `Screen` composable (it has a real VM). Preview only `ScreenContent`.
+- Don't reach into Repository directly from the VM if a UseCase exists. Go through the UseCase.
+- Don't put state-shaped data in `UiEffect`. Only one-shot effects belong there.

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ local.properties
 keystore-base64.txt
 /.kotlin/sessions
 /application.backup
+.claude/settings.local.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,6 +24,13 @@
 - Maintain separation of concerns
 - Don't create new files unless absolutely necessary - prefer editing existing ones
 
+### Screens follow the MVI skill
+For new screens, or when refactoring an existing screen, follow the pattern in `.claude/skills/mvi-screen.md` (invoke `/mvi-screen` for full templates). Key points:
+- Five files per screen: `XxxScreen.kt` (Screen + stateless ScreenContent), `XxxViewModel.kt`, `XxxUiState.kt`, `XxxUiEvent.kt`, `XxxUiEffect.kt`.
+- Initial data fetches go in the ViewModel's `init { }` block, not in a `LaunchedEffect` in the Screen.
+- One-shot effects (navigation, snackbar, toast) flow through `Channel<UiEffect>` and are collected with `ObserverAsEvent` (in `uicomponent/.../util/`). Never raw `LaunchedEffect { effects.collect { } }`.
+- `ScreenContent` is stateless and takes `uiState` + `onEvent` so it can be previewed. The outer `Screen` binds the VM and effects.
+
 ## Testing
 - Always check if tests exist before assuming test framework
 - Look for existing test patterns in the codebase

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -78,6 +78,7 @@ androidx-appcompat = { group = "androidx.appcompat", name = "appcompat", version
 
 # Lifecycle
 androidx-lifecycle-runtime-ktx = { group = "androidx.lifecycle", name = "lifecycle-runtime-ktx", version.ref = "lifecycle" }
+androidx-lifecycle-runtime-compose = { group = "androidx.lifecycle", name = "lifecycle-runtime-compose", version.ref = "lifecycle" }
 androidx-lifecycle-viewmodel-compose = { group = "androidx.lifecycle", name = "lifecycle-viewmodel-compose", version.ref = "lifecycle" }
 
 # Compose BOM

--- a/uicomponent/build.gradle.kts
+++ b/uicomponent/build.gradle.kts
@@ -43,6 +43,7 @@ dependencies {
     // Core
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.lifecycle.runtime.ktx)
+    implementation(libs.androidx.lifecycle.runtime.compose)
     implementation(platform(libs.androidx.compose.bom))
     implementation(libs.androidx.compose.material3)
     api(libs.androidx.compose.material.icons.extended)

--- a/uicomponent/src/main/java/com/android/swingmusic/uicomponent/presentation/util/ObserverAsEvent.kt
+++ b/uicomponent/src/main/java/com/android/swingmusic/uicomponent/presentation/util/ObserverAsEvent.kt
@@ -1,0 +1,25 @@
+package com.android.swingmusic.uicomponent.presentation.util
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.compose.LocalLifecycleOwner
+import androidx.lifecycle.repeatOnLifecycle
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.withContext
+
+@Composable
+fun <T> ObserverAsEvent(
+    flow: Flow<T>,
+    onEvent: (T) -> Unit,
+) {
+    val lifecycleOwner = LocalLifecycleOwner.current
+    LaunchedEffect(flow, lifecycleOwner, onEvent) {
+        lifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+            withContext(Dispatchers.Main.immediate) {
+                flow.collect(onEvent)
+            }
+        }
+    }
+}


### PR DESCRIPTION
Establishes the screen architecture we follow going forward, and ships the small helper the pattern depends on.

## What's in

**`ObserverAsEvent`** in `uicomponent/src/main/java/com/android/swingmusic/uicomponent/presentation/util/`. Lifecycle-aware effect collector. Ties collection to the `STARTED` state and uses `Dispatchers.Main.immediate` so navigation feels synchronous and effects don't fire while the screen is hidden.

```kotlin
ObserverAsEvent(viewModel.uiEffect) { effect ->
    when (effect) { ... }
}
```

Added `lifecycle-runtime-compose` to the version catalog and to `uicomponent`'s deps so we can use `androidx.lifecycle.compose.LocalLifecycleOwner` and `repeatOnLifecycle`. Existing lifecycle version (2.8.7) already supports it, no version bump.

**`.claude/skills/mvi-screen.md`** — the full pattern with templates for each of the five files (Screen + ScreenContent, ViewModel, UiState, UiEvent, UiEffect). Invoke as `/mvi-screen` for the templates. Key conventions baked in:

- Initial data fetches go in the VM `init { }` block. No `LaunchedEffect` for fetches in the Screen.
- One-shot effects flow through a `Channel<UiEffect>` and are always collected with `ObserverAsEvent`. Never raw `LaunchedEffect { effects.collect { } }`.
- No `loadedInitialData` flag, the VM lifecycle handles it.
- `ScreenContent` is stateless so it can be `@Preview`d. The outer `Screen` binds the VM and effects.

**`CLAUDE.md`** — added a short pointer in the Architecture section so the pattern gets applied on every screen task without needing the skill to be explicitly invoked.

**`.gitignore`** — excludes `.claude/settings.local.json` (local user settings) while keeping the skills folder tracked.

## Why now

While working on #104 we noticed the folder screen refetches on every back-nav. Joel asked why, and the answer surfaced that we don't have a standard pattern for "data lives in the VM, screen just reads from it." This PR sets the baseline. Future screen work follows it; existing screens can be migrated incrementally when we touch them.

## Not in scope

No existing screens are migrated in this PR. That can happen one screen at a time as we work on each feature.