### PR TITLE
fix: remember folder scroll and avoid refetch on back-nav (#104)

### DIFF
--- a/feature/folder/src/main/java/com/android/swingmusic/folder/presentation/event/FolderUiEvent.kt
+++ b/feature/folder/src/main/java/com/android/swingmusic/folder/presentation/event/FolderUiEvent.kt
@@ -11,5 +11,7 @@ interface FolderUiEvent {
 
     data class OnRetry(val event: FolderUiEvent) : FolderUiEvent
 
+    data class OnPullToRefresh(val folder: Folder) : FolderUiEvent
+
     data class ToggleTrackFavorite(val trackHash: String, val isFavorite: Boolean) : FolderUiEvent
 }

--- a/feature/folder/src/main/java/com/android/swingmusic/folder/presentation/screen/FoldersAndTracks.kt
+++ b/feature/folder/src/main/java/com/android/swingmusic/folder/presentation/screen/FoldersAndTracks.kt
@@ -150,10 +150,11 @@ private fun FoldersAndTracks(
     val pathsLazyRowState = rememberLazyListState()
 
     LaunchedEffect(currentFolder.path) {
-        val saved = getSavedScroll(currentFolder.path)
+        val effectPath = currentFolder.path
+        val saved = getSavedScroll(effectPath)
         if (saved != null) {
             snapshotFlow { lazyColumnState.layoutInfo.totalItemsCount }
-                .filter { it > 0 }
+                .filter { it > saved.first }
                 .first()
             lazyColumnState.scrollToItem(saved.first, saved.second)
         }
@@ -163,7 +164,7 @@ private fun FoldersAndTracks(
         }
             .drop(1)
             .collect { (index, offset) ->
-                onSaveScroll(currentFolder.path, index, offset)
+                onSaveScroll(effectPath, index, offset)
             }
     }
 

--- a/feature/folder/src/main/java/com/android/swingmusic/folder/presentation/screen/FoldersAndTracks.kt
+++ b/feature/folder/src/main/java/com/android/swingmusic/folder/presentation/screen/FoldersAndTracks.kt
@@ -39,6 +39,10 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshotFlow
+import kotlinx.coroutines.flow.drop
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.first
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.StrokeCap
@@ -90,7 +94,9 @@ private fun FoldersAndTracks(
     onGotoArtist: (hash: String) -> Unit,
     baseUrl: String,
     isManualRefreshing: Boolean,
-    onManualRefreshingChange: (Boolean) -> Unit
+    onManualRefreshingChange: (Boolean) -> Unit,
+    getSavedScroll: (path: String) -> Pair<Int, Int>?,
+    onSaveScroll: (path: String, index: Int, offset: Int) -> Unit
 ) {
     val sheetState = rememberModalBottomSheetState()
     val scope = rememberCoroutineScope()
@@ -134,6 +140,25 @@ private fun FoldersAndTracks(
 
     val lazyColumnState = rememberLazyListState()
     val pathsLazyRowState = rememberLazyListState()
+
+    LaunchedEffect(currentFolder.path) {
+        val saved = getSavedScroll(currentFolder.path)
+        if (saved != null) {
+            snapshotFlow { lazyColumnState.layoutInfo.totalItemsCount }
+                .filter { it > 0 }
+                .first()
+            lazyColumnState.scrollToItem(saved.first, saved.second)
+        }
+
+        snapshotFlow {
+            lazyColumnState.firstVisibleItemIndex to lazyColumnState.firstVisibleItemScrollOffset
+        }
+            .drop(1)
+            .collect { (index, offset) ->
+                onSaveScroll(currentFolder.path, index, offset)
+            }
+    }
+
     Scaffold { it ->
         PullToRefreshBox(
             modifier = Modifier.fillMaxSize(),
@@ -654,7 +679,11 @@ fun FoldersAndTracksScreen(
             onGotoArtist = { hash ->
                 navigator.gotoArtistInfo(hash)
             },
-            baseUrl = baseUrl ?: ""
+            baseUrl = baseUrl ?: "",
+            getSavedScroll = { path -> foldersViewModel.getScrollPosition(path) },
+            onSaveScroll = { path, index, offset ->
+                foldersViewModel.saveScrollPosition(path, index, offset)
+            }
         )
     }
 }

--- a/feature/folder/src/main/java/com/android/swingmusic/folder/presentation/screen/FoldersAndTracks.kt
+++ b/feature/folder/src/main/java/com/android/swingmusic/folder/presentation/screen/FoldersAndTracks.kt
@@ -99,6 +99,14 @@ private fun FoldersAndTracks(
 
     val pagingContent = foldersContentPagingState.pagingContent.collectAsLazyPagingItems()
 
+    val pathsEverShown = remember { mutableStateOf(setOf<String>()) }
+    val isKnownPath = currentFolder.path.trimEnd('/') in pathsEverShown.value
+    LaunchedEffect(pagingContent.itemCount, currentFolder.path) {
+        if (pagingContent.itemCount > 0) {
+            pathsEverShown.value = pathsEverShown.value + currentFolder.path.trimEnd('/')
+        }
+    }
+
     // Track state updates and reset manual refreshing
     LaunchedEffect(pagingContent.loadState, pagingContent.itemCount) {
         // Reset manual refreshing when content loads successfully
@@ -141,9 +149,7 @@ private fun FoldersAndTracks(
             state = refreshState,
             onRefresh = {
                 onManualRefreshingChange(true)
-                // Call fresh data load instead of refresh to avoid pagination issues
-                val event = FolderUiEvent.OnClickFolder(currentFolder)
-                onPullToRefresh(event)
+                onPullToRefresh(FolderUiEvent.OnPullToRefresh(currentFolder))
             },
             indicator = {
                 PullToRefreshDefaults.Indicator(
@@ -379,7 +385,7 @@ private fun FoldersAndTracks(
 
                         when (val refresh = pagingContent.loadState.refresh) {
                             is LoadState.Loading -> {
-                                if (pagingContent.itemCount == 0 && !isManualRefreshing) {
+                                if (pagingContent.itemCount == 0 && !isManualRefreshing && !isKnownPath) {
                                     item {
                                         Box(
                                             modifier = Modifier

--- a/feature/folder/src/main/java/com/android/swingmusic/folder/presentation/viewmodel/FoldersViewModel.kt
+++ b/feature/folder/src/main/java/com/android/swingmusic/folder/presentation/viewmodel/FoldersViewModel.kt
@@ -68,6 +68,11 @@ class FoldersViewModel @Inject constructor(
         mutableStateOf(FoldersContentPagingState())
     val foldersContentPaging: State<FoldersContentPagingState> = _foldersContentPaging
 
+    private val pathFlowCache =
+        mutableMapOf<String, kotlinx.coroutines.flow.Flow<androidx.paging.PagingData<FolderContentItem>>>()
+
+    private fun normalizeFolderPath(path: String): String = path.trimEnd('/')
+
     init {
         getFoldersContentPaging(homeDir.path)
     }
@@ -179,9 +184,20 @@ class FoldersViewModel @Inject constructor(
         return paths
     }
 
-    private fun getFoldersContentPaging(path: String) {
+    private fun getFoldersContentPaging(path: String, forceRefresh: Boolean = false) {
+        val key = normalizeFolderPath(path)
+        if (forceRefresh) {
+            pathFlowCache.remove(key)
+            updatedTrackFavorites.update { emptyMap() }
+        }
+
+        pathFlowCache[key]?.let { cachedFlow ->
+            _foldersContentPaging.value = FoldersContentPagingState(pagingContent = cachedFlow)
+            return
+        }
+
         viewModelScope.launch {
-            val newPagingFlow = folderRepository.getPagingContent(path)
+            val newFlow = folderRepository.getPagingContent(path)
                 .cachedIn(viewModelScope)
                 .combine(updatedTrackFavorites) { pagingData, updatedFavorites ->
                     pagingData.map { contentItem ->
@@ -201,9 +217,8 @@ class FoldersViewModel @Inject constructor(
                     }
                 }
 
-            _foldersContentPaging.value = FoldersContentPagingState(
-                pagingContent = newPagingFlow
-            )
+            pathFlowCache[key] = newFlow
+            _foldersContentPaging.value = FoldersContentPagingState(pagingContent = newFlow)
         }
     }
 
@@ -212,15 +227,12 @@ class FoldersViewModel @Inject constructor(
             is FolderUiEvent.OnClickNavPath -> {
                 if (event.folder.path != _currentFolder.value.path) {
                     _currentFolder.value = event.folder
-                    updatedTrackFavorites.update { emptyMap() }
                     getFoldersContentPaging(event.folder.path)
                 }
             }
 
             is FolderUiEvent.OnClickFolder -> {
                 _currentFolder.value = event.folder
-
-                updatedTrackFavorites.update { emptyMap() }
                 getFoldersContentPaging(event.folder.path)
 
                 val normalizedEventPath = event.folder.path.trimEnd('/')
@@ -243,15 +255,17 @@ class FoldersViewModel @Inject constructor(
                     if (backPathIndex > -1) {
                         val backFolder = _navPaths.value[backPathIndex]
                         _currentFolder.value = backFolder
-                        updatedTrackFavorites.update { emptyMap() }
                         getFoldersContentPaging(backFolder.path)
                     }
                 }
             }
 
             is FolderUiEvent.OnRetry -> {
-                updatedTrackFavorites.update { emptyMap() }
-                getFoldersContentPaging(_currentFolder.value.path)
+                getFoldersContentPaging(_currentFolder.value.path, forceRefresh = true)
+            }
+
+            is FolderUiEvent.OnPullToRefresh -> {
+                getFoldersContentPaging(event.folder.path, forceRefresh = true)
             }
 
             is FolderUiEvent.ToggleTrackFavorite -> {

--- a/feature/folder/src/main/java/com/android/swingmusic/folder/presentation/viewmodel/FoldersViewModel.kt
+++ b/feature/folder/src/main/java/com/android/swingmusic/folder/presentation/viewmodel/FoldersViewModel.kt
@@ -68,6 +68,17 @@ class FoldersViewModel @Inject constructor(
         mutableStateOf(FoldersContentPagingState())
     val foldersContentPaging: State<FoldersContentPagingState> = _foldersContentPaging
 
+    private val folderScrollPositions = mutableMapOf<String, Pair<Int, Int>>()
+
+    private fun normalizeFolderPath(path: String): String = path.trimEnd('/')
+
+    fun saveScrollPosition(path: String, index: Int, offset: Int) {
+        folderScrollPositions[normalizeFolderPath(path)] = index to offset
+    }
+
+    fun getScrollPosition(path: String): Pair<Int, Int>? =
+        folderScrollPositions[normalizeFolderPath(path)]
+
     init {
         getFoldersContentPaging(homeDir.path)
     }


### PR DESCRIPTION
Closes #104. Supersedes #118.

## Scroll position memory

Each folder remembers where you scrolled to. Tapping back returns you to that scroll position at every nesting level.

`FoldersViewModel` keeps a normalized-path map of `(firstVisibleIndex, firstVisibleOffset)`. The composable saves and restores in a `LaunchedEffect` keyed on `currentFolder.path`. Path normalized with `trimEnd('/')` on both save and lookup because the VM uses different trailing-slash forms between forward and back nav.

The restore effect waits for `totalItemsCount > saved.first` before calling `scrollToItem`. A "wait for any item" check failed on cache hits where the first paged item appeared in `layoutInfo` within a millisecond, making `scrollToItem` a no-op because the target index didn't exist yet.

## Paging cache per folder path

Going back to a folder no longer refetches.

`FoldersViewModel` keeps a `Map<String, Flow<PagingData<FolderContentItem>>>` keyed by normalized path. The existing `cachedIn(viewModelScope)` lives inside the cached Flow, so revisits reuse the cached `PagingData` without hitting the network. Plain nav events look up the Flow and only build on miss. Pull-to-refresh and `OnRetry` pass `forceRefresh = true` which evicts then rebuilds.

`OnPullToRefresh` is a new explicit event so pull-to-refresh no longer routes through `OnClickFolder` (which would now be a cache hit).

The `updatedTrackFavorites.update { emptyMap() }` calls on plain nav events were dropped. Those wipes caused the `combine` operator to re-emit a fresh `PagingData` through the cached pipeline (flickering the list) and were also clearing user-toggled favorites in this session. Only `forceRefresh` wipes favorites now.

A small screen-side guard remembers paths that have ever shown items so the empty-state spinner doesn't briefly flash on cache-hit re-subscription.

## Tested on Pixel 7 Pro

- Deep scroll, into subfolder, back: position restored
- Multi-level (A → A/B → A/B/C, back-back-back): each level restores
- Breadcrumb up the tree: instant, no fetch
- Tab switch and return: state survives
- Pull-to-refresh: evicts and refetches