### PR TITLE
`feat:` Lyrics Overlay (Replace Lyrics Screen With In-Player Overlay)

### DIFF
--- a/app/src/main/java/com/android/swingmusic/presentation/navigator/CoreNavigator.kt
+++ b/app/src/main/java/com/android/swingmusic/presentation/navigator/CoreNavigator.kt
@@ -9,7 +9,6 @@ import com.android.swingmusic.auth.presentation.screen.destinations.LoginWithUse
 import com.android.swingmusic.common.presentation.navigator.CommonNavigator
 import com.android.swingmusic.folder.presentation.screen.destinations.FoldersAndTracksScreenDestination
 import com.android.swingmusic.home.presentation.destinations.HomeDestination
-import com.android.swingmusic.player.presentation.screen.destinations.LyricsScreenDestination
 import com.android.swingmusic.player.presentation.screen.destinations.QueueScreenDestination
 import com.android.swingmusic.search.presentation.screen.destinations.ViewAllSearchResultsDestination
 import com.ramcosta.composedestinations.navigation.navigate
@@ -143,12 +142,6 @@ class CoreNavigator(
     override fun gotoSourceFolder(name: String, path: String) {
         val targetDestination = FoldersAndTracksScreenDestination(name, path)
         navController.navigate(targetDestination) {
-            launchSingleTop = true
-        }
-    }
-
-    override fun gotoLyrics() {
-        navController.navigate(LyricsScreenDestination) {
             launchSingleTop = true
         }
     }

--- a/app/src/main/java/com/android/swingmusic/presentation/navigator/NavGraphs.kt
+++ b/app/src/main/java/com/android/swingmusic/presentation/navigator/NavGraphs.kt
@@ -9,7 +9,6 @@ import com.android.swingmusic.auth.presentation.screen.destinations.LoginWithQrC
 import com.android.swingmusic.auth.presentation.screen.destinations.LoginWithUsernameScreenDestination
 import com.android.swingmusic.folder.presentation.screen.destinations.FoldersAndTracksScreenDestination
 import com.android.swingmusic.home.presentation.destinations.HomeDestination
-import com.android.swingmusic.player.presentation.screen.destinations.LyricsScreenDestination
 import com.android.swingmusic.player.presentation.screen.destinations.NowPlayingScreenDestination
 import com.android.swingmusic.player.presentation.screen.destinations.QueueScreenDestination
 import com.android.swingmusic.search.presentation.screen.destinations.SearchScreenDestination
@@ -44,7 +43,6 @@ object NavGraphs {
                     // inner destinations
                     NowPlayingScreenDestination,
                     QueueScreenDestination,
-                    LyricsScreenDestination,
                     AlbumWithInfoScreenDestination,
                     ViewAllScreenOnArtistDestination,
                     ArtistInfoScreenDestination,

--- a/feature/common/src/main/java/com/android/swingmusic/common/presentation/navigator/CommonNavigator.kt
+++ b/feature/common/src/main/java/com/android/swingmusic/common/presentation/navigator/CommonNavigator.kt
@@ -25,6 +25,4 @@ interface CommonNavigator {
 
     fun gotoSourceFolder(name: String, path: String)
 
-    fun gotoLyrics()
-
 }

--- a/feature/player/src/main/java/com/android/swingmusic/player/presentation/screen/AnimatedPlayerSheet.kt
+++ b/feature/player/src/main/java/com/android/swingmusic/player/presentation/screen/AnimatedPlayerSheet.kt
@@ -185,6 +185,9 @@ fun AnimatedPlayerSheet(
     // Track if closing sheet is allowed (set by long-press)
     var allowSheetClose by remember { mutableStateOf(false) }
 
+    // Lyrics overlay visibility (shown on top of the player without leaving the screen)
+    var showLyrics by remember { mutableStateOf(false) }
+
     // Queue sheet calculations
     val configuration = LocalConfiguration.current
     val density = LocalDensity.current
@@ -277,7 +280,7 @@ fun AnimatedPlayerSheet(
         sheetDragHandle = {},
         sheetShape = dynamicShape,
         sheetContainerColor = MaterialTheme.colorScheme.inverseOnSurface,
-        sheetSwipeEnabled = !isQueueSheetOpen,
+        sheetSwipeEnabled = !isQueueSheetOpen && !showLyrics,
         sheetContent = {
             if (playingTrack != null) {
                 AnimatedSheetContent(
@@ -340,10 +343,7 @@ fun AnimatedPlayerSheet(
                         allowSheetClose = true
                     },
                     onClickLyricsIcon = {
-                        coroutineScope.launch {
-                            bottomSheetState.bottomSheetState.partialExpand()
-                            navigator.gotoLyrics()
-                        }
+                        showLyrics = true
                     }
                 )
             }
@@ -352,8 +352,14 @@ fun AnimatedPlayerSheet(
         content(innerPadding)
     }
 
-    // Queue Sheet - appears when primary sheet is fully expanded and has a track
-    if (primarySheetProgress >= 0.95f && playingTrack != null) {
+    // Queue Sheet - appears when primary sheet is fully expanded and has a track.
+    // Only compose it while it's actually open or animating (offset moved off its parked
+    // position). When fully parked, its offset (screenHeightDp, which omits the system-bar
+    // height) leaves an invisible sliver of the alpha(0) sheet over the player's bottom
+    // controls that would otherwise swallow their taps.
+    if (primarySheetProgress >= 0.95f && playingTrack != null &&
+        queueSheetOffset.value < queueInitialOffset - 1f
+    ) {
         QueueSheetOverlay(
             queue = playerUiState.queue,
             source = playerUiState.source,
@@ -391,6 +397,13 @@ fun AnimatedPlayerSheet(
             }
         )
     }
+
+    // Lyrics overlay - rendered last so it sits above the player and queue sheets
+    LyricsOverlay(
+        visible = showLyrics,
+        mediaControllerViewModel = mediaControllerViewModel,
+        onDismiss = { showLyrics = false }
+    )
 }
 
 @OptIn(ExperimentalAnimationGraphicsApi::class, ExperimentalFoundationApi::class)

--- a/feature/player/src/main/java/com/android/swingmusic/player/presentation/screen/LyricsScreen.kt
+++ b/feature/player/src/main/java/com/android/swingmusic/player/presentation/screen/LyricsScreen.kt
@@ -1,11 +1,19 @@
 package com.android.swingmusic.player.presentation.screen
 
+import android.content.res.Configuration
+import androidx.activity.compose.BackHandler
+import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.animateColorAsState
 import androidx.compose.animation.core.FastOutSlowInEasing
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.slideInVertically
+import androidx.compose.animation.slideOutVertically
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -15,6 +23,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.statusBarsPadding
@@ -25,37 +34,53 @@ import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.KeyboardArrowDown
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.graphics.TransformOrigin
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Devices
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewDynamicColors
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
 import coil.compose.AsyncImage
 import coil.request.ImageRequest
-import androidx.compose.ui.platform.LocalContext
 import com.android.swingmusic.common.presentation.navigator.CommonNavigator
+import com.android.swingmusic.core.domain.model.LyricsLine
 import com.android.swingmusic.core.domain.model.Track
+import com.android.swingmusic.core.domain.model.TrackArtist
+import com.android.swingmusic.core.domain.util.PlaybackState
 import com.android.swingmusic.player.presentation.event.LyricsUiEvent
 import com.android.swingmusic.player.presentation.event.PlayerUiEvent
+import com.android.swingmusic.player.presentation.state.LyricsUiState
 import com.android.swingmusic.player.presentation.viewmodel.LyricsViewModel
 import com.android.swingmusic.player.presentation.viewmodel.MediaControllerViewModel
+import com.android.swingmusic.uicomponent.R
+import com.android.swingmusic.uicomponent.presentation.theme.SwingMusicTheme
 import com.ramcosta.composedestinations.annotation.Destination
 import kotlin.math.abs
 
@@ -103,7 +128,11 @@ fun LyricsScreen(
                     val durationMs = track.duration * 1000F
                     if (durationMs > 0F) {
                         val fraction = (timeMs.toFloat() / durationMs).coerceIn(0F, 1F)
-                        mediaControllerViewModel.onPlayerUiEvent(PlayerUiEvent.OnSeekPlayBack(fraction))
+                        mediaControllerViewModel.onPlayerUiEvent(
+                            PlayerUiEvent.OnSeekPlayBack(
+                                fraction
+                            )
+                        )
                     }
                 }
             },
@@ -112,6 +141,281 @@ fun LyricsScreen(
                 track?.let { lyricsViewModel.onEvent(LyricsUiEvent.SearchOnline(it)) }
             }
         )
+    }
+}
+
+/**
+ * Edge-to-edge lyrics overlay shown on top of the animated player sheet.
+ *
+ * Unlike [LyricsScreen] this is not a navigation destination: it renders above the
+ * player without collapsing it, so dismissing returns to the expanded player rather
+ * than popping the back stack. The overlay is non-dismissable by tap/swipe — it is
+ * closed only via the header chevron or the back gesture.
+ */
+@Composable
+fun LyricsOverlay(
+    visible: Boolean,
+    mediaControllerViewModel: MediaControllerViewModel,
+    onDismiss: () -> Unit,
+    lyricsViewModel: LyricsViewModel = hiltViewModel()
+) {
+    val playerUiState by mediaControllerViewModel.playerUiState.collectAsState()
+    val baseUrl by mediaControllerViewModel.baseUrl.collectAsState()
+    val lyricsState by lyricsViewModel.state.collectAsState()
+    val track = playerUiState.nowPlayingTrack
+
+    LaunchedEffect(visible, track?.trackHash) {
+        if (visible) {
+            track?.let { lyricsViewModel.onEvent(LyricsUiEvent.LoadLyrics(it)) }
+        }
+    }
+
+    LaunchedEffect(visible, playerUiState.seekPosition, lyricsState.exists, lyricsState.synced) {
+        if (visible && lyricsState.exists && lyricsState.synced && track != null) {
+            val positionMs = (playerUiState.seekPosition * track.duration * 1000F).toLong()
+            lyricsViewModel.onEvent(LyricsUiEvent.PositionChanged(positionMs))
+        }
+    }
+
+    AnimatedVisibility(
+        visible = visible,
+        enter = fadeIn(tween(200)) + slideInVertically(tween(280)) { it / 6 },
+        exit = fadeOut(tween(180)) + slideOutVertically(tween(220)) { it / 6 }
+    ) {
+        BackHandler(enabled = true) { onDismiss() }
+
+        LyricsOverlayContent(
+            track = track,
+            baseUrl = baseUrl ?: "",
+            state = lyricsState,
+            loading = lyricsState.isLoading || playerUiState.isBuffering,
+            playbackState = playerUiState.playbackState,
+            progress = playerUiState.seekPosition,
+            onDismiss = onDismiss,
+            onTogglePlayback = {
+                mediaControllerViewModel.onPlayerUiEvent(PlayerUiEvent.OnTogglePlayerState)
+            },
+            onSeek = { timeMs ->
+                if (track != null) {
+                    val durationMs = track.duration * 1000F
+                    if (durationMs > 0F) {
+                        val fraction = (timeMs.toFloat() / durationMs).coerceIn(0F, 1F)
+                        mediaControllerViewModel.onPlayerUiEvent(
+                            PlayerUiEvent.OnSeekPlayBack(fraction)
+                        )
+                    }
+                }
+            },
+            onUserScrolled = { lyricsViewModel.onEvent(LyricsUiEvent.SetUserScrolled(it)) },
+            onSearchOnline = {
+                track?.let { lyricsViewModel.onEvent(LyricsUiEvent.SearchOnline(it)) }
+            }
+        )
+    }
+}
+
+@Composable
+private fun LyricsOverlayContent(
+    track: Track?,
+    baseUrl: String,
+    state: LyricsUiState,
+    loading: Boolean,
+    playbackState: PlaybackState,
+    progress: Float,
+    onDismiss: () -> Unit,
+    onSeek: (Long) -> Unit,
+    onUserScrolled: (Boolean) -> Unit,
+    onSearchOnline: () -> Unit,
+    onTogglePlayback: () -> Unit
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(MaterialTheme.colorScheme.surface)
+            // Swallow taps on empty areas so they don't fall through to the player sheet
+            // behind. Drags are handled by disabling the sheet's swipe while the overlay
+            // is open (see AnimatedPlayerSheet); this clickable ignores drags, so the
+            // lyrics list scrolls normally.
+            .clickable(
+                interactionSource = remember { MutableInteractionSource() },
+                indication = null
+            ) { }
+            .statusBarsPadding()
+            .navigationBarsPadding()
+    ) {
+        LyricsOverlayHeader(
+            track = track,
+            baseUrl = baseUrl,
+            synced = state.synced,
+            exists = state.exists,
+            loading = loading,
+            playbackState = playbackState,
+            onDismiss = onDismiss,
+            onTogglePlayback = onTogglePlayback
+        )
+
+        // Progress bar doubling as the divider: unfilled track mimics the divider
+        // color, filled portion shows how far into the track playback is.
+        LinearProgressIndicator(
+            progress = { progress },
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(2.dp),
+            color = MaterialTheme.colorScheme.primary,
+            trackColor = MaterialTheme.colorScheme.outlineVariant,
+            gapSize = 0.dp,
+            drawStopIndicator = {},
+            strokeCap = StrokeCap.Square
+        )
+
+        Box(
+            modifier = Modifier
+                .weight(1F)
+                .fillMaxWidth()
+        ) {
+            LyricsBody(
+                padding = PaddingValues(0.dp),
+                track = track,
+                state = state,
+                onSeek = onSeek,
+                onUserScrolled = onUserScrolled,
+                onSearchOnline = onSearchOnline
+            )
+
+            // Soft fade just below the divider so lyrics melt into the top edge
+            // instead of touching the divider line.
+            Box(
+                modifier = Modifier
+                    .align(Alignment.TopCenter)
+                    .fillMaxWidth()
+                    .height(48.dp)
+                    .background(
+                        Brush.verticalGradient(
+                            colors = listOf(
+                                MaterialTheme.colorScheme.surface,
+                                Color.Transparent
+                            )
+                        )
+                    )
+            )
+
+            // Matching fade at the bottom so lyrics melt out instead of cutting off.
+            Box(
+                modifier = Modifier
+                    .align(Alignment.BottomCenter)
+                    .fillMaxWidth()
+                    .height(48.dp)
+                    .background(
+                        Brush.verticalGradient(
+                            colors = listOf(
+                                Color.Transparent,
+                                MaterialTheme.colorScheme.surface
+                            )
+                        )
+                    )
+            )
+        }
+    }
+}
+
+@Composable
+private fun LyricsOverlayHeader(
+    track: Track?,
+    baseUrl: String,
+    synced: Boolean,
+    exists: Boolean,
+    loading: Boolean,
+    playbackState: PlaybackState,
+    onDismiss: () -> Unit,
+    onTogglePlayback: () -> Unit
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 12.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        if (track != null) {
+            Box(
+                modifier = Modifier
+                    .size(48.dp)
+                    .clip(RoundedCornerShape(8.dp))
+                    .clickable { onTogglePlayback() },
+                contentAlignment = Alignment.Center
+            ) {
+                AsyncImage(
+                    model = ImageRequest.Builder(LocalContext.current)
+                        .data("${baseUrl}img/thumbnail/${track.image}")
+                        .crossfade(true)
+                        .build(),
+                    contentDescription = null,
+                    contentScale = ContentScale.Crop,
+                    modifier = Modifier.fillMaxSize()
+                )
+                Box(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .background(Color.Black.copy(alpha = 0.35F))
+                )
+                if (loading) {
+                    CircularProgressIndicator(
+                        modifier = Modifier.size(22.dp),
+                        strokeWidth = 2.dp,
+                        color = Color.White
+                    )
+                } else {
+                    Icon(
+                        painter = painterResource(
+                            id = if (playbackState == PlaybackState.PLAYING)
+                                R.drawable.pause_icon else R.drawable.play_arrow
+                        ),
+                        contentDescription = if (playbackState == PlaybackState.PLAYING) "Pause" else "Play",
+                        tint = Color.White,
+                        modifier = Modifier.size(22.dp)
+                    )
+                }
+            }
+            Spacer(Modifier.size(12.dp))
+            Column(modifier = Modifier.weight(1F)) {
+                Text(
+                    text = track.title,
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.SemiBold,
+                    maxLines = 1
+                )
+                val artistText = track.trackArtists.joinToString(", ") { it.name }
+                Text(
+                    text = artistText,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.7F),
+                    maxLines = 1
+                )
+            }
+            if (exists && !synced) {
+                Box(
+                    modifier = Modifier
+                        .clip(RoundedCornerShape(6.dp))
+                        .background(MaterialTheme.colorScheme.secondaryContainer)
+                        .padding(horizontal = 8.dp, vertical = 4.dp)
+                ) {
+                    Text(
+                        text = "unsynced",
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.onSecondaryContainer
+                    )
+                }
+                Spacer(Modifier.size(8.dp))
+            }
+        } else {
+            Spacer(Modifier.weight(1F))
+        }
+
+        IconButton(onClick = onDismiss) {
+            Icon(
+                imageVector = Icons.Filled.KeyboardArrowDown,
+                contentDescription = "Close lyrics"
+            )
+        }
     }
 }
 
@@ -189,7 +493,7 @@ private fun LyricsHeader(
 private fun LyricsBody(
     padding: PaddingValues,
     track: Track?,
-    state: com.android.swingmusic.player.presentation.state.LyricsUiState,
+    state: LyricsUiState,
     onSeek: (Long) -> Unit,
     onUserScrolled: (Boolean) -> Unit,
     onSearchOnline: () -> Unit
@@ -228,7 +532,7 @@ private fun LyricsBody(
 
 @Composable
 private fun SyncedLyricsList(
-    state: com.android.swingmusic.player.presentation.state.LyricsUiState,
+    state: LyricsUiState,
     onSeek: (Long) -> Unit,
     onUserScrolled: (Boolean) -> Unit
 ) {
@@ -251,7 +555,8 @@ private fun SyncedLyricsList(
 
         if (!state.userScrolled || !isCentered) {
             val target = state.currentLine.coerceAtLeast(0)
-            val viewportHeight = listState.layoutInfo.viewportEndOffset - listState.layoutInfo.viewportStartOffset
+            val viewportHeight =
+                listState.layoutInfo.viewportEndOffset - listState.layoutInfo.viewportStartOffset
             listState.animateScrollToItem(target, scrollOffset = -(viewportHeight / 3))
             onUserScrolled(false)
         }
@@ -260,8 +565,8 @@ private fun SyncedLyricsList(
     LazyColumn(
         state = listState,
         modifier = Modifier.fillMaxSize(),
-        contentPadding = PaddingValues(horizontal = 24.dp, vertical = 32.dp),
-        verticalArrangement = Arrangement.spacedBy(8.dp)
+        contentPadding = PaddingValues(vertical = 32.dp),
+        verticalArrangement = Arrangement.spacedBy(2.dp)
     ) {
         itemsIndexed(state.lines, key = { i, _ -> i }) { index, line ->
             val current = state.currentLine
@@ -294,23 +599,29 @@ private fun SyncedLyricsList(
                 label = "lyricColor"
             )
 
-            Text(
-                text = line.text.ifBlank { "♪" },
-                fontSize = 32.sp,
-                lineHeight = 40.sp,
-                fontWeight = if (isActive) FontWeight.Bold else FontWeight.SemiBold,
-                color = animatedColor,
+            Box(
                 modifier = Modifier
                     .fillMaxWidth()
                     .clickable { onSeek(line.time) }
-                    .graphicsLayer {
-                        scaleX = animatedScale
-                        scaleY = animatedScale
-                        transformOrigin = TransformOrigin(0F, 0.5F)
-                    }
-                    .padding(vertical = 4.dp)
-            )
+                    .padding(horizontal = 24.dp, vertical = 4.dp)
+            ) {
+                Text(
+                    text = line.text.ifBlank { "♪" },
+                    fontSize = 32.sp,
+                    lineHeight = 40.sp,
+                    fontWeight = if (isActive) FontWeight.Bold else FontWeight.SemiBold,
+                    color = animatedColor,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .graphicsLayer {
+                            scaleX = animatedScale
+                            scaleY = animatedScale
+                            transformOrigin = TransformOrigin(0F, 0.5F)
+                        }
+                )
+            }
         }
+
         if (state.copyright.isNotBlank()) {
             item {
                 Text(
@@ -321,7 +632,7 @@ private fun SyncedLyricsList(
                 )
             }
         }
-        item { Spacer(Modifier.height(128.dp)) }
+        item { Spacer(Modifier.height(24.dp)) }
     }
 }
 
@@ -351,7 +662,7 @@ private fun UnsyncedLyricsList(
                 )
             }
         }
-        item { Spacer(Modifier.height(128.dp)) }
+        item { Spacer(Modifier.height(24.dp)) }
     }
 }
 
@@ -385,6 +696,76 @@ private fun EmptyLyricsState(
                     Text("Search online")
                 }
             }
+        }
+    }
+}
+
+@PreviewDynamicColors
+@Preview(
+    uiMode = Configuration.UI_MODE_NIGHT_YES,
+    device = Devices.PIXEL_5,
+    showBackground = true
+)
+@Composable
+fun LyricsOverlayPreview() {
+    val sia = TrackArtist(
+        artistHash = "sia123",
+        image = "sia.jpg",
+        name = "Sia"
+    )
+
+    val track = Track(
+        album = "This Is Acting",
+        albumTrackArtists = listOf(sia),
+        albumHash = "albumHash123",
+        trackArtists = listOf(sia),
+        bitrate = 320,
+        duration = 240,
+        filepath = "/path/to/track.mp3",
+        folder = "/path/to/folder",
+        image = "/path/to/album/artwork.jpg",
+        isFavorite = false,
+        title = "Bird Set Free",
+        trackHash = "trackHash123",
+        disc = 1,
+        trackNumber = 1
+    )
+
+    val lines = listOf(
+        "Holding my breath against the cold",
+        "Waiting for the morning to call",
+        "But there's a fire in my chest",
+        "Burning brighter than before",
+        "I will rise above the noise",
+        "And walk straight through the open door",
+        "No more hiding, no more fear",
+        "Let the silence break apart"
+    ).mapIndexed { index, text -> LyricsLine(time = index * 6000L, text = text) }
+
+    val state = LyricsUiState(
+        lines = lines,
+        synced = true,
+        exists = true,
+        currentLine = 2,
+        trackHash = track.trackHash
+    )
+
+
+    SwingMusicTheme(dynamicColor = true) {
+        Surface() {
+            LyricsOverlayContent(
+                track = track,
+                baseUrl = "",
+                state = state,
+                loading = false,
+                playbackState = PlaybackState.PLAYING,
+                progress = 0.35F,
+                onDismiss = {},
+                onSeek = {},
+                onUserScrolled = {},
+                onSearchOnline = {},
+                onTogglePlayback = {}
+            )
         }
     }
 }

--- a/feature/player/src/main/java/com/android/swingmusic/player/presentation/screen/LyricsScreen.kt
+++ b/feature/player/src/main/java/com/android/swingmusic/player/presentation/screen/LyricsScreen.kt
@@ -33,14 +33,12 @@ import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.KeyboardArrowDown
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
@@ -69,7 +67,6 @@ import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
 import coil.compose.AsyncImage
 import coil.request.ImageRequest
-import com.android.swingmusic.common.presentation.navigator.CommonNavigator
 import com.android.swingmusic.core.domain.model.LyricsLine
 import com.android.swingmusic.core.domain.model.Track
 import com.android.swingmusic.core.domain.model.TrackArtist
@@ -81,76 +78,14 @@ import com.android.swingmusic.player.presentation.viewmodel.LyricsViewModel
 import com.android.swingmusic.player.presentation.viewmodel.MediaControllerViewModel
 import com.android.swingmusic.uicomponent.R
 import com.android.swingmusic.uicomponent.presentation.theme.SwingMusicTheme
-import com.ramcosta.composedestinations.annotation.Destination
 import kotlin.math.abs
-
-@Destination
-@Composable
-fun LyricsScreen(
-    mediaControllerViewModel: MediaControllerViewModel,
-    navigator: CommonNavigator,
-    lyricsViewModel: LyricsViewModel = hiltViewModel()
-) {
-    val playerUiState by mediaControllerViewModel.playerUiState.collectAsState()
-    val baseUrl by mediaControllerViewModel.baseUrl.collectAsState()
-    val lyricsState by lyricsViewModel.state.collectAsState()
-    val track = playerUiState.nowPlayingTrack
-
-    LaunchedEffect(track?.trackHash) {
-        track?.let { lyricsViewModel.onEvent(LyricsUiEvent.LoadLyrics(it)) }
-    }
-
-    LaunchedEffect(playerUiState.seekPosition, lyricsState.exists, lyricsState.synced) {
-        if (lyricsState.exists && lyricsState.synced && track != null) {
-            val positionMs = (playerUiState.seekPosition * track.duration * 1000F).toLong()
-            lyricsViewModel.onEvent(LyricsUiEvent.PositionChanged(positionMs))
-        }
-    }
-
-    Scaffold(
-        topBar = {
-            LyricsHeader(
-                track = track,
-                baseUrl = baseUrl ?: "",
-                synced = lyricsState.synced,
-                exists = lyricsState.exists,
-                onBack = { navigator.navigateBack() },
-                onClickArtist = { hash -> navigator.gotoArtistInfo(hash) }
-            )
-        }
-    ) { padding ->
-        LyricsBody(
-            padding = padding,
-            track = track,
-            state = lyricsState,
-            onSeek = { timeMs ->
-                if (track != null) {
-                    val durationMs = track.duration * 1000F
-                    if (durationMs > 0F) {
-                        val fraction = (timeMs.toFloat() / durationMs).coerceIn(0F, 1F)
-                        mediaControllerViewModel.onPlayerUiEvent(
-                            PlayerUiEvent.OnSeekPlayBack(
-                                fraction
-                            )
-                        )
-                    }
-                }
-            },
-            onUserScrolled = { lyricsViewModel.onEvent(LyricsUiEvent.SetUserScrolled(it)) },
-            onSearchOnline = {
-                track?.let { lyricsViewModel.onEvent(LyricsUiEvent.SearchOnline(it)) }
-            }
-        )
-    }
-}
 
 /**
  * Edge-to-edge lyrics overlay shown on top of the animated player sheet.
  *
- * Unlike [LyricsScreen] this is not a navigation destination: it renders above the
- * player without collapsing it, so dismissing returns to the expanded player rather
- * than popping the back stack. The overlay is non-dismissable by tap/swipe — it is
- * closed only via the header chevron or the back gesture.
+ * It renders above the player without collapsing it, so dismissing returns to the
+ * expanded player rather than popping the back stack. The overlay is non-dismissable
+ * by tap/swipe — it is closed only via the header chevron or the back gesture.
  */
 @Composable
 fun LyricsOverlay(
@@ -415,76 +350,6 @@ private fun LyricsOverlayHeader(
                 imageVector = Icons.Filled.KeyboardArrowDown,
                 contentDescription = "Close lyrics"
             )
-        }
-    }
-}
-
-@Composable
-private fun LyricsHeader(
-    track: Track?,
-    baseUrl: String,
-    synced: Boolean,
-    exists: Boolean,
-    onBack: () -> Unit,
-    onClickArtist: (String) -> Unit
-) {
-    Row(
-        modifier = Modifier
-            .fillMaxWidth()
-            .statusBarsPadding()
-            .padding(horizontal = 12.dp, vertical = 8.dp),
-        verticalAlignment = Alignment.CenterVertically
-    ) {
-        IconButton(onClick = onBack) {
-            Icon(imageVector = Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
-        }
-        if (track != null) {
-            AsyncImage(
-                model = ImageRequest.Builder(LocalContext.current)
-                    .data("${baseUrl}img/thumbnail/${track.image}")
-                    .crossfade(true)
-                    .build(),
-                contentDescription = null,
-                contentScale = ContentScale.Crop,
-                modifier = Modifier
-                    .size(48.dp)
-                    .clip(RoundedCornerShape(8.dp))
-            )
-            Spacer(Modifier.size(12.dp))
-            Column(modifier = Modifier.weight(1F)) {
-                Text(
-                    text = track.title,
-                    style = MaterialTheme.typography.titleMedium,
-                    fontWeight = FontWeight.SemiBold,
-                    maxLines = 1
-                )
-                val artistText = track.trackArtists.joinToString(", ") { it.name }
-                Text(
-                    text = artistText,
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.7F),
-                    maxLines = 1,
-                    modifier = if (track.trackArtists.isNotEmpty()) {
-                        Modifier.clickable {
-                            onClickArtist(track.trackArtists.first().artistHash)
-                        }
-                    } else Modifier
-                )
-            }
-            if (exists && !synced) {
-                Box(
-                    modifier = Modifier
-                        .clip(RoundedCornerShape(6.dp))
-                        .background(MaterialTheme.colorScheme.secondaryContainer)
-                        .padding(horizontal = 8.dp, vertical = 4.dp)
-                ) {
-                    Text(
-                        text = "unsynced",
-                        style = MaterialTheme.typography.labelSmall,
-                        color = MaterialTheme.colorScheme.onSecondaryContainer
-                    )
-                }
-            }
         }
     }
 }

--- a/feature/player/src/main/java/com/android/swingmusic/player/presentation/screen/NowPlaying.kt
+++ b/feature/player/src/main/java/com/android/swingmusic/player/presentation/screen/NowPlaying.kt
@@ -670,9 +670,8 @@ fun NowPlayingScreen(
                 PlayerUiEvent.OnSeekPlayBack(it)
             )
         },
-        onClickLyricsIcon = {
-            navigator.gotoLyrics()
-        },
+        // Legacy screen: lyrics are shown via the overlay on the animated player, not here.
+        onClickLyricsIcon = { },
         onToggleFavorite = { isFavorite, trackHash ->
             mediaControllerViewModel.onPlayerUiEvent(
                 PlayerUiEvent.OnToggleFavorite(isFavorite, trackHash)


### PR DESCRIPTION
🚧 **Draft — do not merge yet (for review).**

## What
Replaces the full-screen Lyrics navigation destination with a full-screen **overlay** rendered on top of the animated player sheet, plus a set of UI refinements.

## Why
Tapping the lyrics icon previously navigated to a separate `LyricsScreen` destination, which collapsed the player sheet and left the back stack pointing at Folders — pressing back dropped you out of the player entirely. The overlay renders above the player without leaving the route, so dismissing returns to the expanded player.

https://github.com/user-attachments/assets/af99bff4-6918-4f72-925e-8515cfb03956


## Changes
- **`LyricsOverlay`** — full-screen, non-navigation overlay over the player; opened from the lyrics icon (`showLyrics`), dismissed via the header chevron or back gesture. Modal: consumes gestures so they don't fall through to the sheet.
- **Play/pause on the artwork** — tap the header thumbnail to toggle playback; shows a spinner while lyrics load / the track buffers.
- **Progress bar as the header divider** — the divider doubles as a track-progress indicator.
- **Top & bottom fade gradients** so lyrics melt into the edges.
- **Tighter inactive-line spacing.**
- **Fix: bottom player controls were unclickable** — a pre-existing bug where the parked `QueueSheetOverlay` left an invisible, touch-stealing sliver over the bottom controls; it's now only composed while open.
- Disables sheet swipe while the overlay is open so a drag can't collapse the player underneath.

## Notes
- The old `LyricsScreen` `@Destination` is left intact (still used by `NowPlaying.kt`).
- Manually verified: overlay open/close, lyric tap-to-seek, scrolling, play/pause toggle, queue open/close, and bottom controls clickable.
