### PR TITLE
Fix Folders error after fresh login

### DIFF
--- a/feature/folder/src/main/java/com/android/swingmusic/folder/presentation/viewmodel/FoldersViewModel.kt
+++ b/feature/folder/src/main/java/com/android/swingmusic/folder/presentation/viewmodel/FoldersViewModel.kt
@@ -7,6 +7,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import androidx.paging.cachedIn
 import androidx.paging.map
+import com.android.swingmusic.auth.domain.repository.AuthRepository
 import com.android.swingmusic.core.data.util.Resource
 import com.android.swingmusic.core.domain.model.Folder
 import com.android.swingmusic.core.domain.model.FoldersAndTracks
@@ -27,7 +28,8 @@ import javax.inject.Inject
 @HiltViewModel
 class FoldersViewModel @Inject constructor(
     private val folderRepository: FolderRepository,
-    private val pLayerRepository: PLayerRepository
+    private val pLayerRepository: PLayerRepository,
+    private val authRepository: AuthRepository
 ) : ViewModel() {
     val homeDir: Folder = Folder(
         path = "\$home",
@@ -83,7 +85,15 @@ class FoldersViewModel @Inject constructor(
         folderScrollPositions[normalizeFolderPath(path)]
 
     init {
-        getFoldersContentPaging(homeDir.path)
+        viewModelScope.launch {
+            // This VM is activity-scoped and may be created before login. Fetching without
+            // credentials would cache a Pager built with a null base URL/token that keeps
+            // failing after login. Skip instead: FoldersAndTracksScreen triggers the first
+            // fetch once the base URL becomes available.
+            if (authRepository.getAccessToken() != null && authRepository.getBaseUrl() != null) {
+                getFoldersContentPaging(homeDir.path)
+            }
+        }
     }
 
     fun resetNavPathsForGotoFolder(targetPath: String) {


### PR DESCRIPTION
## Summary
- `FoldersViewModel` is activity-scoped and is created while the login screen is still showing. Its `init` block fetched `$home` immediately, baking a null base URL (literal `"nullfolder"`) and a missing bearer token into the Pager's `pagingSourceFactory`, and caching that broken flow in `pathFlowCache`.
- After login, the Folders screen reused the poisoned cache entry (the screen's base-URL effect calls `getFoldersContentPaging` without `forceRefresh`), so every load kept failing with a network error until a manual retry or pull-to-refresh — while all other screens (whose ViewModels are destination-scoped and created post-login) worked fine.
- Fix: skip the `init` fetch when auth credentials aren't available yet. The screen's existing base-URL `LaunchedEffect` performs the first fetch right after login, when the token and base URL are valid. Behavior for an already-logged-in app start is unchanged.

## Test plan
- `:app:assembleDebug` builds clean.
- Verified on emulator: cold start while logged in still loads Folders normally (the `init` path with credentials present).
- Recommended manual check: fresh install → log in → Folders should load without the network error.